### PR TITLE
 Standardize dataset paths + add CI to run all audits

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -1,0 +1,42 @@
+name: Audits
+
+# Smoke-test every audit so a broken dataset path or script
+# (like the AI Fair Recruitment FileNotFoundError) is caught automatically.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  run-audits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run all audit scripts
+        run: |
+          set -e
+          for audit in \
+            "COMPAS" \
+            "AI Fair Recruitment" \
+            "German Credit Lending" \
+            "Insurance Denial" \
+            "Benefits Denial"; do
+            echo "::group::$audit — unfair.py"
+            python "$audit/unfair.py"
+            echo "::endgroup::"
+            echo "::group::$audit — fair.py"
+            python "$audit/fair.py"
+            echo "::endgroup::"
+          done

--- a/AI Fair Recruitment/fair.py
+++ b/AI Fair Recruitment/fair.py
@@ -1,9 +1,10 @@
 import pandas as pd
+from pathlib import Path
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
 
 # 1. Load the dataset
-df = pd.read_csv('AI Fair Recruitment/AI_Fair_Recruitment_Dataset.csv')
+df = pd.read_csv(Path(__file__).parent / 'AI_Fair_Recruitment_Dataset.csv')
 
 # Drop missing metrics safely
 df = df.dropna(subset=['Hiring_Decision', 'Gender', 'Age', 'Experience_Years', 'Technical_Test_Score'])

--- a/AI Fair Recruitment/unfair.py
+++ b/AI Fair Recruitment/unfair.py
@@ -1,9 +1,10 @@
 import pandas as pd
+from pathlib import Path
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
 
 # 1. Load the dataset
-df = pd.read_csv('AI Fair Recruitment/AI_Fair_Recruitment_Dataset.csv')
+df = pd.read_csv(Path(__file__).parent / 'AI_Fair_Recruitment_Dataset.csv')
 
 # Drop missing metrics safely
 df = df.dropna(subset=['Hiring_Decision', 'Gender', 'Age', 'Experience_Years', 'Technical_Test_Score'])

--- a/Benefits Denial/fair.py
+++ b/Benefits Denial/fair.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from pathlib import Path
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
@@ -28,7 +29,7 @@ from sklearn.metrics import accuracy_score
 #   capital.loss     signals that directly affect means tests
 # ============================================================
 
-df = pd.read_csv('Benefits Denial/adult.csv')
+df = pd.read_csv(Path(__file__).parent / 'adult.csv')
 
 df['target']    = (df['income'] == '>50K').astype(int)
 df['is_female'] = (df['sex'] == 'Female').astype(int)

--- a/Benefits Denial/unfair.py
+++ b/Benefits Denial/unfair.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from pathlib import Path
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
@@ -30,7 +31,7 @@ from sklearn.metrics import accuracy_score
 #                   Occupation encodes race via labour market bias.
 # ============================================================
 
-df = pd.read_csv('Benefits Denial/adult.csv')
+df = pd.read_csv(Path(__file__).parent / 'adult.csv')
 
 # Target: 1 = income >50K (above means-test threshold → likely ineligible)
 #         0 = income <=50K (below threshold → eligible for benefits)

--- a/COMPAS/fair.py
+++ b/COMPAS/fair.py
@@ -1,9 +1,10 @@
 import pandas as pd
+from pathlib import Path
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
 
 # 1. Load Data
-df = pd.read_csv('COMPAS/compas-scores-raw.csv')
+df = pd.read_csv(Path(__file__).parent / 'compas-scores-raw.csv')
 df = df[df['Ethnic_Code_Text'].isin(['African-American', 'Caucasian'])]
 df = df[df['DisplayText'] == 'Risk of Recidivism']
 

--- a/COMPAS/unfair.py
+++ b/COMPAS/unfair.py
@@ -1,9 +1,10 @@
 import pandas as pd
+from pathlib import Path
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
 
 # 1. Load your uploaded file
-df = pd.read_csv('COMPAS/compas-scores-raw.csv')
+df = pd.read_csv(Path(__file__).parent / 'compas-scores-raw.csv')
 
 # 2. Filter for clear comparison (African-American vs Caucasian) 
 # and focus on 'Risk of Recidivism'

--- a/German Credit Lending/fair.py
+++ b/German Credit Lending/fair.py
@@ -1,10 +1,11 @@
 import pandas as pd
+from pathlib import Path
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
 
 # Load dataset
-df = pd.read_csv('credit_customers.csv')
+df = pd.read_csv(Path(__file__).parent / 'credit_customers.csv')
 
 df['target'] = (df['class'] == 'good').astype(int)
 df['is_young'] = (df['age'] < 30).astype(int)

--- a/German Credit Lending/unfair.py
+++ b/German Credit Lending/unfair.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from pathlib import Path
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
@@ -6,7 +7,7 @@ from sklearn.preprocessing import LabelEncoder
 # Load dataset
 # Source: German Credit Risk dataset
 # https://www.kaggle.com/datasets/ppb00x/credit-risk-customers
-df = pd.read_csv('credit_customers.csv')
+df = pd.read_csv(Path(__file__).parent / 'credit_customers.csv')
 
 # Target: 1 = good credit, 0 = bad credit
 df['target'] = (df['class'] == 'good').astype(int)

--- a/Insurance Denial/fair.py
+++ b/Insurance Denial/fair.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from pathlib import Path
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score
@@ -16,7 +17,7 @@ from sklearn.metrics import accuracy_score
 # race, class, or protected status.
 # ============================================================
 
-df = pd.read_csv('Insurance Denial/insurance.csv')
+df = pd.read_csv(Path(__file__).parent / 'insurance.csv')
 
 # Same binarization threshold as unfair.py — valid comparison.
 median_charge = df['claim'].median()

--- a/Insurance Denial/unfair.py
+++ b/Insurance Denial/unfair.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from pathlib import Path
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score
@@ -21,7 +22,7 @@ from sklearn.metrics import accuracy_score
 # racial signal through an apparently clinical variable.
 # ============================================================
 
-df = pd.read_csv('Insurance Denial/insurance.csv')
+df = pd.read_csv(Path(__file__).parent / 'insurance.csv')
 
 # Binarize continuous claim charges at the median.
 # Above median = high-cost claim (flagged for denial/review).

--- a/README.md
+++ b/README.md
@@ -428,12 +428,14 @@ cd Fair-Code
 pip install -r requirements.txt
 ```
 
-Run any audit:
+Run any audit from the repository root:
 
 ```bash
-cd COMPAS && python unfair.py   # see the bias
-cd COMPAS && python fair.py     # see the fix
+python COMPAS/unfair.py   # see the bias
+python COMPAS/fair.py     # see the fix
 ```
+
+Each script resolves its dataset relative to its own location, so it runs from anywhere — `cd COMPAS && python unfair.py` works too.
 
 The same pattern applies to all five projects — swap `COMPAS` for `"AI Fair Recruitment"`, `"German Credit Lending"`, `"Insurance Denial"`, or `"Benefits Denial"`.
 


### PR DESCRIPTION
This PR standardizes how every audit script locates its dataset, fixes a script that was completely broken, and adds CI so these regressions are caught automatically.

Previously the five audits used three different and partly broken path conventions. The README told users to run cd COMPAS && python unfair.py, but every root-relative script breaks under that instruction (the path resolves to COMPAS/COMPAS/...). And the AI Fair Recruitment scripts pointed at a folder (Ai Fair recrutment Dataset/) that does not exist in the repo, so both crashed immediately with FileNotFoundError.
1. Standardized dataset loading across all 5 audits Every unfair.py / fair.py now resolves its dataset relative to the script's own location:

from pathlib import Path
df = pd.read_csv(Path(__file__).parent / '<dataset>.csv')

This makes each script runnable from any working directory — repo root, inside the audit folder, or anywhere else — and removes the three inconsistent conventions.

2. Updated README The "Getting Started" section now shows running from the repo root and notes that cd-ing into a folder also works, so the docs match the code.

3. Added CI (.github/workflows/audits.yml) On every push and PR, the workflow installs dependencies and runs all 10 audit scripts as a smoke test. This would have caught the AI Fair Recruitment FileNotFoundError automatically.