### PR TITLE
Fix: First Interaction Trigger Change, Audits Workflow Enhancement and Version Upgrade  

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -11,6 +11,15 @@ on:
 jobs:
   run-audits:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        audit:
+          - "COMPAS"
+          - "AI Fair Recruitment"
+          - "German Credit Lending"
+          - "Insurance Denial"
+          - "Benefits Denial"
     steps:
       - uses: actions/checkout@v4
 
@@ -24,19 +33,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run all audit scripts
+      - name: Run ${{ matrix.audit }} audit scripts
         run: |
           set -e
-          for audit in \
-            "COMPAS" \
-            "AI Fair Recruitment" \
-            "German Credit Lending" \
-            "Insurance Denial" \
-            "Benefits Denial"; do
-            echo "::group::$audit — unfair.py"
-            python "$audit/unfair.py"
-            echo "::endgroup::"
-            echo "::group::$audit — fair.py"
-            python "$audit/fair.py"
-            echo "::endgroup::"
-          done
+          echo "::group::${{ matrix.audit }} — unfair.py"
+          python "${{ matrix.audit }}/unfair.py"
+          echo "::endgroup::"
+          echo "::group::${{ matrix.audit }} — fair.py"
+          python "${{ matrix.audit }}/fair.py"
+          echo "::endgroup::"

--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -21,9 +21,9 @@ jobs:
           - "Insurance Denial"
           - "Benefits Denial"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/first.interaction.yml
+++ b/.github/workflows/first.interaction.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/first-interaction@v1
+      - uses: actions/first-interaction@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-message: |

--- a/.github/workflows/first.interaction.yml
+++ b/.github/workflows/first.interaction.yml
@@ -3,7 +3,7 @@ name: First Interaction
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # full history needed
 


### PR DESCRIPTION
## What does this PR do?

Changed first interaction trigger to pull_request_target to fix 403 permission errors on PRs from external forks.
Refactored audits workflow to use a Matrix strategy, running all 5 dataset tests in parallel. And also this means that one case failure won't affect pthers.
Bumped all GitHub actions to their latest versions to remove the Node 20 deprecation warnings.

## Type

- [ ] Audit
- [ ] Explainer
- [x] Bug fix
- [ ] Other (describe below)

---

Just fixed them because I noticed these things when I opened my PR here. Minor but QoL changes. 
