### PR TITLE
feat: add profile score CI gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,6 +794,7 @@ faircode profile data.tsv                          # tab-separated exports work 
 faircode profile data.xlsx                         # Excel workbooks work too
 faircode profile data.csv --json                   # machine-readable
 faircode profile data.csv --html report.html       # standalone HTML report
+faircode profile data.csv --fail-under 70          # fail CI if score is below 70
 faircode compare train.csv prod.csv                # representation drift, A → B (PSI)
 faircode profile data.csv --map gndr=sex           # fix a missed column
 faircode profile data.csv --cross race,age         # choose the intersection pair
@@ -801,6 +802,11 @@ faircode profile data.csv --reference census.csv   # score vs a population basel
 faircode profile data.csv --proxy-hints            # chi-squared proxy hints (needs scipy)
 faircode profile data.csv --min-share 0.1          # tune the flagging thresholds
 ```
+
+For CI, `--fail-under N` returns exit code `1` and explains the failing score
+on stderr when the overall representation score is below `N`; report output,
+including `--json`, remains on stdout. A score at or above the threshold exits
+successfully.
 
 The engine is domain-agnostic - it works on any tabular CSV (health, hiring, lending, justice),
 auto-detecting demographic columns (sex, race, age, geography) by name. Beyond the single-dataset

--- a/faircode/cli.py
+++ b/faircode/cli.py
@@ -79,6 +79,8 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--json", action="store_true", help="emit JSON to stdout")
     p.add_argument("--html", metavar="PATH",
                    help="write a standalone HTML report to PATH")
+    p.add_argument("--fail-under", type=float, metavar="N",
+                   help="exit 1 when the overall representation score is below N")
     p.add_argument("--map", action="append", metavar="COL=KIND",
                    help="force a column's dimension when auto-detection misses it; "
                         "KIND is one of " + ", ".join(_MAP_CHOICES) + " (repeatable)")
@@ -164,6 +166,13 @@ def main(argv: list[str] | None = None) -> int:
             print(to_json(result))
         else:
             print(to_terminal(result))
+        if args.fail_under is not None and result["overall_score"] < args.fail_under:
+            print(
+                f"error: representation score {result['overall_score']}/100 is below "
+                f"--fail-under {args.fail_under:g}",
+                file=sys.stderr,
+            )
+            return 1
         return 0
 
     if args.command == "compare":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,27 @@
+import json
+
+from faircode.cli import main
+
+
+def test_profile_fail_under_returns_nonzero_and_explains_score(tmp_path, capsys):
+    path = tmp_path / "skewed.csv"
+    path.write_text("sex\n" + "M\n" * 80 + "F\n" * 20, encoding="utf-8")
+
+    exit_code = main(["profile", str(path), "--fail-under", "90"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Representation score:" in captured.out
+    assert "representation score 72/100 is below --fail-under 90" in captured.err
+
+
+def test_profile_fail_under_keeps_json_output_machine_readable(tmp_path, capsys):
+    path = tmp_path / "balanced.csv"
+    path.write_text("sex\nM\nF\nM\nF\n", encoding="utf-8")
+
+    exit_code = main(["profile", str(path), "--json", "--fail-under", "90"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert json.loads(captured.out)["overall_score"] == 100
+    assert captured.err == ""


### PR DESCRIPTION
## What changed

Added `faircode profile --fail-under N` as a CI gate. The profile report still goes to stdout, including JSON mode; when the overall score is below the threshold, the command returns exit code `1` and writes a one-line explanation to stderr. Scores at or above the threshold keep the existing successful exit.

The README now documents the flag and exit-code contract. The optional `--fail-on-flags` idea is intentionally left for a separate change.

## Validation

- `python -m pytest -q`: 94 passed, 2 dataset-dependent tests skipped.
- Ruff checks pass for the CLI and new tests.
- `python -m compileall -q faircode tests` passes.
- `git diff --check` passes.

Closes #115
