### PR TITLE
Add equality test for --fail-under threshold

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,3 +25,14 @@ def test_profile_fail_under_keeps_json_output_machine_readable(tmp_path, capsys)
     assert exit_code == 0
     assert json.loads(captured.out)["overall_score"] == 100
     assert captured.err == ""
+def test_profile_fail_under_equal_threshold_returns_zero(tmp_path, capsys):
+    path = tmp_path / "balanced.csv"
+    path.write_text("sex\nM\nF\nM\nF\n", encoding="utf-8")
+
+    exit_code = main(["profile", str(path), "--fail-under", "100"])
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Representation score:" in captured.out
+    assert captured.err == ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,5 +34,5 @@ def test_profile_fail_under_equal_threshold_returns_zero(tmp_path, capsys):
     captured = capsys.readouterr()
 
     assert exit_code == 0
-    assert "Representation score:" in captured.out
+    assert "Representation score: 100/100" in captured.out
     assert captured.err == ""


### PR DESCRIPTION
## Summary

Add a CLI test covering the `overall_score == --fail-under` boundary case and verify that the command returns exit code `0` when the score exactly equals the threshold, matching the documented behavior.

## Type

- [ ] Audit
- [ ] Explainer
- [x] Bug fix
- [ ] Other

---

## Linked issue

Closes #117