### PR TITLE
Fix theme toggle to respect system preference

### DIFF
--- a/explainers/accuracy-not-enough-healthcare-ai.html
+++ b/explainers/accuracy-not-enough-healthcare-ai.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -277,9 +278,10 @@ def majority_class_baseline(y_true):
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -287,7 +289,7 @@ def majority_class_baseline(y_true):
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/ai-hallucinations.html
+++ b/explainers/ai-hallucinations.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -309,9 +310,10 @@ audit_hallucination_risk(df_expanded, [&#x27;bmi_cat&#x27;, &#x27;smoker&#x27;, 
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -319,7 +321,7 @@ audit_hallucination_risk(df_expanded, [&#x27;bmi_cat&#x27;, &#x27;smoker&#x27;, 
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/ai-objectivity-myth.html
+++ b/explainers/ai-objectivity-myth.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -279,9 +280,10 @@ def find_features_explaining_gap(df, protected_col, candidate_cols, p_threshold=
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -289,7 +291,7 @@ def find_features_explaining_gap(df, protected_col, candidate_cols, p_threshold=
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/automation-bias.html
+++ b/explainers/automation-bias.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -319,9 +320,10 @@ print(result)
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -329,7 +331,7 @@ print(result)
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/bias-variance-tradeoff.html
+++ b/explainers/bias-variance-tradeoff.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -257,9 +258,10 @@ def check_variance_by_group(model, X_train, y_train, X_test, y_test, group_col):
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -267,7 +269,7 @@ def check_variance_by_group(model, X_train, y_train, X_test, y_test, group_col):
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/calibration.html
+++ b/explainers/calibration.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -288,9 +289,10 @@ calibration_gap(results)</code></pre>
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -298,7 +300,7 @@ calibration_gap(results)</code></pre>
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/class-imbalance.html
+++ b/explainers/class-imbalance.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -256,9 +257,10 @@ def audit_imbalance(X, y, protected_attribute):
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -266,7 +268,7 @@ def audit_imbalance(X, y, protected_attribute):
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/confounding-variable.html
+++ b/explainers/confounding-variable.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -326,9 +327,10 @@ print(result[&quot;confounder_vs_protected&quot;])
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -336,7 +338,7 @@ print(result[&quot;confounder_vs_protected&quot;])
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/confusion-matrix.html
+++ b/explainers/confusion-matrix.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -254,9 +255,10 @@ def group_confusion_metrics(df, y_true_col, y_pred_col, group_col):
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -264,7 +266,7 @@ def group_confusion_metrics(df, y_true_col, y_pred_col, group_col):
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/counterfactual-fairness.html
+++ b/explainers/counterfactual-fairness.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -400,9 +401,10 @@ print(f&quot;Fair model violation rate: {len(violations_fair)/len(cf_df)*100:.1f
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -410,7 +412,7 @@ print(f&quot;Fair model violation rate: {len(violations_fair)/len(cf_df)*100:.1f
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/data-leakage.html
+++ b/explainers/data-leakage.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -345,9 +346,10 @@ if __name__ == &quot;__main__&quot;:
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -355,7 +357,7 @@ if __name__ == &quot;__main__&quot;:
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/demographic-parity.html
+++ b/explainers/demographic-parity.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -320,9 +321,10 @@ def plot_parity_gap(rates_df, group_col, rate_col=&#x27;positive_rate&#x27;, tit
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -330,7 +332,7 @@ def plot_parity_gap(rates_df, group_col, rate_col=&#x27;positive_rate&#x27;, tit
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/disparate-impact.html
+++ b/explainers/disparate-impact.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -316,9 +317,10 @@ print(f&quot;DI ratio: {ratio:.3f}  |  passes 80% rule: {ratio &gt;= 0.80}&quot;
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -326,7 +328,7 @@ print(f&quot;DI ratio: {ratio:.3f}  |  passes 80% rule: {ratio &gt;= 0.80}&quot;
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/disparate-treatment.html
+++ b/explainers/disparate-treatment.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -377,9 +378,10 @@ proxy_treatment_check(df, feature_col=&#x27;employment&#x27;, protected_col=&#x2
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -387,7 +389,7 @@ proxy_treatment_check(df, feature_col=&#x27;employment&#x27;, protected_col=&#x2
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/distribution-shift.html
+++ b/explainers/distribution-shift.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -314,9 +315,10 @@ def detect_label_shift(reference_df, current_df, label_col, alpha=0.05):
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -324,7 +326,7 @@ def detect_label_shift(reference_df, current_df, label_col, alpha=0.05):
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/equalized-odds.html
+++ b/explainers/equalized-odds.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -284,9 +285,10 @@ FPR    0.20</code></pre>
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -294,7 +296,7 @@ FPR    0.20</code></pre>
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/fairness-metric-conflicts.html
+++ b/explainers/fairness-metric-conflicts.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -400,9 +401,10 @@ print(audit)</code></pre>
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -410,7 +412,7 @@ print(audit)</code></pre>
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/false-positives-vs-false-negatives.html
+++ b/explainers/false-positives-vs-false-negatives.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -286,9 +287,10 @@ def cost_weighted_threshold(y_true, y_prob, fn_cost=5, fp_cost=1, thresholds=Non
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -296,7 +298,7 @@ def cost_weighted_threshold(y_true, y_prob, fn_cost=5, fp_cost=1, thresholds=Non
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/feedback-loop-bias.html
+++ b/explainers/feedback-loop-bias.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -343,9 +344,10 @@ print_feedback_report(results, group_col=&#x27;race&#x27;)</code></pre>
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -353,7 +355,7 @@ print_feedback_report(results, group_col=&#x27;race&#x27;)</code></pre>
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/how-ai-detects-patterns.html
+++ b/explainers/how-ai-detects-patterns.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -283,9 +284,10 @@ def flag_correlated_patterns(df, protected_attr, candidate_features, threshold=0
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -293,7 +295,7 @@ def flag_correlated_patterns(df, protected_attr, candidate_features, threshold=0
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/individual-fairness.html
+++ b/explainers/individual-fairness.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -467,9 +468,10 @@ d_fair = [&#x27;experience_years&#x27;, &#x27;technical_test_score&#x27;]
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -477,7 +479,7 @@ d_fair = [&#x27;experience_years&#x27;, &#x27;technical_test_score&#x27;]
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/label-bias.html
+++ b/explainers/label-bias.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -444,9 +445,10 @@ mitigator.fit(
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -454,7 +456,7 @@ mitigator.fit(
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/ml-bias.html
+++ b/explainers/ml-bias.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -334,9 +335,10 @@ def check_proxy(df, feature_col, protected_col, p_threshold=0.05):
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -344,7 +346,7 @@ def check_proxy(df, feature_col, protected_col, p_threshold=0.05):
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/model-drift.html
+++ b/explainers/model-drift.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -312,9 +313,10 @@ def rolling_fairness_gap(df, protected_col, label_col, n_windows=5):
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -322,7 +324,7 @@ def rolling_fairness_gap(df, protected_col, label_col, n_windows=5):
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/neural-networks.html
+++ b/explainers/neural-networks.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -357,9 +358,10 @@ sex ──────────────┘
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -367,7 +369,7 @@ sex ──────────────┘
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/predictive-parity.html
+++ b/explainers/predictive-parity.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -275,9 +276,10 @@ def base_rate_gap(df: pd.DataFrame, y_true: str, group_col: str):
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -285,7 +287,7 @@ def base_rate_gap(df: pd.DataFrame, y_true: str, group_col: str):
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/protected-attribute.html
+++ b/explainers/protected-attribute.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -249,9 +250,10 @@ def test_fairness_through_unawareness(df, protected_col):
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -259,7 +261,7 @@ def test_fairness_through_unawareness(df, protected_col):
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/proxy-entanglement.html
+++ b/explainers/proxy-entanglement.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -352,9 +353,10 @@ def detect_proxy_entanglement(df, protected_col, candidate_proxies, p_threshold=
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -362,7 +364,7 @@ def detect_proxy_entanglement(df, protected_col, candidate_proxies, p_threshold=
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/proxy-variables.html
+++ b/explainers/proxy-variables.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -261,9 +262,10 @@ print(result)
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -271,7 +273,7 @@ print(result)
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/reinforcement-learning.html
+++ b/explainers/reinforcement-learning.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -446,9 +447,10 @@ def recommendation_reward(user_action, content_type):
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -456,7 +458,7 @@ def recommendation_reward(user_action, content_type):
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/roc-curve-auc.html
+++ b/explainers/roc-curve-auc.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -275,9 +276,10 @@ def group_roc_points(df, y_true_col, y_score_col, group_col):
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -285,7 +287,7 @@ def group_roc_points(df, y_true_col, y_score_col, group_col):
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/sampling-bias.html
+++ b/explainers/sampling-bias.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -336,9 +337,10 @@ X_train, X_test, y_train, y_test = train_test_split(
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -346,7 +348,7 @@ X_train, X_test, y_train, y_test = train_test_split(
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/selection-bias.html
+++ b/explainers/selection-bias.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -313,9 +314,10 @@ def check_outcome_rate_against_reference(df, outcome_col, positive_value, refere
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -323,7 +325,7 @@ def check_outcome_rate_against_reference(df, outcome_col, positive_value, refere
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/shap-values.html
+++ b/explainers/shap-values.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -330,9 +331,10 @@ print(audit.head(10))</code></pre>
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -340,7 +342,7 @@ print(audit.head(10))</code></pre>
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/supervised-learning.html
+++ b/explainers/supervised-learning.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -308,9 +309,10 @@ def compare_label_vs_prediction_gap(df, protected_col, label_col, test_index, pr
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -318,7 +320,7 @@ def compare_label_vs_prediction_gap(df, protected_col, label_col, test_index, pr
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/explainers/unsupervised-learning.html
+++ b/explainers/unsupervised-learning.html
@@ -28,7 +28,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -279,9 +280,10 @@ def check_cluster_demographic_skew(df, cluster_labels, protected_col):
     (function () {
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
@@ -289,7 +291,7 @@ def check_cluster_demographic_skew(df, cluster_labels, protected_col):
       syncTheme();
 
       toggle.addEventListener('click', () => {
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/index.html
+++ b/index.html
@@ -261,7 +261,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    var saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    var saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -3174,7 +3175,8 @@
   // Theme toggle
   const toggle = document.getElementById('themeToggle');
   const html = document.documentElement;
-  const saved = localStorage.getItem('fc-theme') || 'light';
+  const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  const saved = localStorage.getItem('fc-theme') || systemPref;
   html.setAttribute('data-theme', saved);
   toggle.textContent = saved === 'light' ? '☾' : '☀';
   toggle.setAttribute('aria-label', saved === 'light' ? 'Switch to dark mode' : 'Switch to light mode');

--- a/profiler.html
+++ b/profiler.html
@@ -56,7 +56,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {
-    var saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    var saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   })();
 </script>
@@ -281,14 +282,15 @@
     (function () {
       var toggle = document.getElementById('themeToggle');
       var html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
       function sync() {
-        var cur = html.getAttribute('data-theme') || 'light';
+        var cur = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = cur === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', cur === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }
       sync();
       toggle.addEventListener('click', function () {
-        var next = (html.getAttribute('data-theme') || 'light') === 'dark' ? 'light' : 'dark';
+        var next = (html.getAttribute('data-theme') || systemPref) === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);
         sync();

--- a/scripts/build_explainers.py
+++ b/scripts/build_explainers.py
@@ -296,7 +296,8 @@ PAGE_TEMPLATE = """<!DOCTYPE html>
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Archivo:wght@400;500;600;700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <script>
   (function () {{
-    const saved = localStorage.getItem('fc-theme') || 'light';
+    const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const saved = localStorage.getItem('fc-theme') || systemPref;
     document.documentElement.setAttribute('data-theme', saved);
   }})();
 </script>
@@ -382,9 +383,10 @@ PAGE_TEMPLATE = """<!DOCTYPE html>
     (function () {{
       const toggle = document.getElementById('explainerThemeToggle');
       const html = document.documentElement;
+      const systemPref = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       function syncTheme() {{
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         toggle.textContent = current === 'light' ? '☾' : '☀';
         toggle.setAttribute('aria-label', current === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
       }}
@@ -392,7 +394,7 @@ PAGE_TEMPLATE = """<!DOCTYPE html>
       syncTheme();
 
       toggle.addEventListener('click', () => {{
-        const current = html.getAttribute('data-theme') || 'dark';
+        const current = html.getAttribute('data-theme') || systemPref;
         const next = current === 'dark' ? 'light' : 'dark';
         html.setAttribute('data-theme', next);
         localStorage.setItem('fc-theme', next);

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,7 +6,7 @@
   </url>
   <url>
     <loc>https://www.thefaircode.xyz/profiler.html</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-05</lastmod>
   </url>
   <url>
     <loc>https://www.thefaircode.xyz/explainers/proxy-variables.html</loc>


### PR DESCRIPTION
## Summary

Update the theme toggle to respect the user's system preference (`prefers-color-scheme: dark`) on their first visit. 

Previously, the site defaulted to a hardcoded light theme until manually toggled, ignoring OS/browser settings. This replaces the hardcoded fallback with `window.matchMedia` across `index.html`, `profiler.html`, and the explainer pages, while still ensuring an explicitly saved choice in `localStorage` wins.

Closes #135