### PR TITLE
Add client-side JSON support to the web profiler

### DIFF
--- a/assets/profiler-compare.js
+++ b/assets/profiler-compare.js
@@ -74,16 +74,20 @@
   function readFile(key, file, drop, nameEl) {
     if (/\.xlsx$/i.test(file.name)) {
       return showError('Excel (.xlsx) isn\'t supported in the browser profiler yet - ' +
-        'export to CSV/TSV first, or use the "faircode compare" CLI.');
+        'export to CSV/TSV/JSON first, or use the "faircode compare" CLI.');
     }
-    var okExt = /\.(csv|tsv)$/i.test(file.name);
-    var okType = file.type === 'text/csv' || file.type === 'text/tab-separated-values';
-    if (!okExt && !okType) return showError('Please choose a .csv or .tsv file.');
+    var okExt = /\.(csv|tsv|json)$/i.test(file.name);
+    var okType = file.type === 'text/csv' || file.type === 'text/tab-separated-values' || file.type === 'application/json';
+    if (!okExt && !okType) return showError('Please choose a .csv, .tsv, or .json file.');
 
     var reader = new FileReader();
     reader.onload = function () {
       try {
-        var table = E.parseCSV(String(reader.result));
+        if (/\.json$/i.test(file.name) || file.type === 'application/json') {
+          var table = E.parseJSON(String(reader.result));
+        } else {
+          var table = E.parseCSV(String(reader.result));
+        }
         if (!table.columns.length || !table.rows.length) {
           return showError('Dataset ' + key + ' looks empty or has no data rows.');
         }
@@ -352,8 +356,8 @@
   }
 
   function compareReportBaseName() {
-    var an = ((slot.A && slot.A.name) || 'A').replace(/\.(csv|tsv)$/i, '');
-    var bn = ((slot.B && slot.B.name) || 'B').replace(/\.(csv|tsv)$/i, '');
+    var an = ((slot.A && slot.A.name) || 'A').replace(/\.(csv|tsv|json)$/i, '');
+    var bn = ((slot.B && slot.B.name) || 'B').replace(/\.(csv|tsv|json)$/i, '');
     return an + '-vs-' + bn + '-drift-report';
   }
 

--- a/assets/profiler-engine.js
+++ b/assets/profiler-engine.js
@@ -134,6 +134,58 @@
     }
     return { columns: columns, rows: data };
   }
+// ── JSON parsing ──────────────────────────────────────────────────────────
+// Handles Pandas/standard JSON in records ([{col: val}]) and split ({columns: [...], data: [[...]]}) formats.
+function parseJSON(text) {
+  if (typeof text !== 'string') text = String(text);
+  if (text.charCodeAt(0) === 0xFEFF) text = text.slice(1); // strip BOM
+  var parsed = JSON.parse(text); // Let invalid JSON syntax throw to caller
+  if (!parsed) return { columns: [], rows: [] };
+
+  // 1. Records format: [ { colA: 1, colB: 2 }, ... ]
+  if (Array.isArray(parsed)) {
+    if (!parsed.length) return { columns: [], rows: [] };
+    if (!parsed[0] || typeof parsed[0] !== "object" || Array.isArray(parsed[0])) {
+      throw new Error("Unsupported JSON format (expected records or split orientation).");
+    }
+    var columns = Object.keys(parsed[0] || {});
+    var rows = [];
+
+    for (var i = 0; i < parsed.length; i++) {
+      var item = parsed[i] || {};
+      var obj = {};
+      for (var ci = 0; ci < columns.length; ci++) {
+        var raw = item[columns[ci]];
+        raw = raw === undefined ? '' : raw;
+        obj[columns[ci]] = isMissing(raw) ? null : raw;
+      }
+      rows.push(obj);
+    }
+    return { columns: columns, rows: rows };
+  }
+
+  // 2. Split format: { columns: ["colA", "colB"], data: [[1, 2], ...] }
+  if (typeof parsed === 'object' && Array.isArray(parsed.columns) && Array.isArray(parsed.data)) {
+    
+    var columns = parsed.columns.map(String);
+    var rows = [];
+
+    for (var r = 0; r < parsed.data.length; r++) {
+      var rowVal = parsed.data[r] || [];
+      var obj = {};
+      for (var ci = 0; ci < columns.length; ci++) {
+        var raw = rowVal[ci];
+        raw = raw === undefined ? '' : raw;
+        obj[columns[ci]] = isMissing(raw) ? null : raw;
+      }
+      rows.push(obj);
+    }
+    return { columns: columns, rows: rows };
+  }
+
+  // 3. Reject non-tabular / unsupported objects explicitly
+  throw new Error('Unsupported JSON format (expected records or split orientation).');
+}
 
   function isMissing(v) {
     if (v === null || v === undefined) return true;
@@ -663,7 +715,7 @@
     };
   }
 
-  global.FairCodeProfiler = { parseCSV: parseCSV, sniffDelimiter: sniffDelimiter,
+  global.FairCodeProfiler = { parseCSV: parseCSV, parseJSON: parseJSON, sniffDelimiter: sniffDelimiter,
                               profile: profile, compare: compare,
                               parseReference: parseReference };
 })(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/assets/profiler-ui.js
+++ b/assets/profiler-ui.js
@@ -107,12 +107,12 @@
   function readFile(file) {
     if (/\.xlsx$/i.test(file.name)) {
       return showError('Excel (.xlsx) isn\'t supported in the browser profiler yet - ' +
-        'run "faircode profile ' + file.name + '" from the CLI, or export to CSV/TSV first.');
+        'run "faircode profile ' + file.name + '" from the CLI, or export to CSV/TSV/JSON first.');
     }
-    var okExt = /\.(csv|tsv)$/i.test(file.name);
-    var okType = file.type === 'text/csv' || file.type === 'text/tab-separated-values';
+    var okExt = /\.(csv|tsv|json)$/i.test(file.name);
+    var okType = file.type === 'text/csv' || file.type === 'text/tab-separated-values' || file.type === 'application/json';
     if (!okExt && !okType) {
-      return showError('Please choose a .csv or .tsv file.');
+      return showError('Please choose a .csv, .tsv or .json file.');
     }
     var reader = new FileReader();
     reader.onload = function () { runText(String(reader.result), file.name); };
@@ -122,9 +122,13 @@
 
   function runText(text, name) {
     try {
-      var table = E.parseCSV(text);
+      if (/\.json$/i.test(name) || text.trim().startsWith('{')) {
+        var table = E.parseJSON(text);
+      } else {
+        var table = E.parseCSV(text);
+      }
       if (!table.columns.length || !table.rows.length) {
-        return showError('That CSV looks empty or has no data rows.');
+        return showError('That file looks empty or has no data rows.');
       }
       currentTable = table;
       currentOverrides = {};
@@ -399,7 +403,11 @@
     var reader = new FileReader();
     reader.onload = function () {
       try {
-        currentOpts.reference = E.parseReference(E.parseCSV(String(reader.result)));
+        if (/\.json$/i.test(f.name) || f.type === 'application/json') {
+          currentOpts.reference = E.parseReference(E.parseJSON(String(reader.result)));
+        } else {
+          currentOpts.reference = E.parseReference(E.parseCSV(String(reader.result)));
+        }
         referenceStatus.textContent = '⚖ scored vs ' + f.name;
         referenceClearBtn.hidden = false;
         reprofile(false);
@@ -485,7 +493,7 @@
   }
 
   function reportBaseName() {
-    return (currentName || 'dataset').replace(/\.csv$/i, '') + '-profile-report';
+    return (currentName || 'dataset').replace(/\.csv|\.tsv|\.json$/i, '') + '-profile-report';
   }
 
   function downloadHtmlReport() {

--- a/profiler.html
+++ b/profiler.html
@@ -157,12 +157,12 @@
     </section>
 
     <section class="dropzone" id="dropzone" tabindex="0" role="button"
-             aria-label="Upload a CSV or TSV file, or click to browse"
+             aria-label="Upload a CSV, TSV or JSON file, or click to browse"
              aria-describedby="dropzoneHint">
-      <input type="file" id="fileInput" accept=".csv,.tsv,text/csv,text/tab-separated-values" hidden>
+      <input type="file" id="fileInput" accept=".csv,.tsv,.json,text/csv,text/tab-separated-values,text/plain,application/json" hidden>
       <div class="dropzone-inner">
         <div class="dropzone-icon" aria-hidden="true">⊕</div>
-        <p class="dropzone-title">Drop a CSV or TSV here, or <span class="link">browse</span></p>
+        <p class="dropzone-title">Drop a CSV, TSV or JSON file here, or <span class="link">browse</span></p>
         <p class="dropzone-hint" id="dropzoneHint">Comma- or tab-separated values, with a header row. (Excel files:
         use <code>faircode profile data.xlsx</code> from the CLI.)</p>
         <button class="sample-btn" id="sampleBtn" type="button">Try it with a sample dataset</button>
@@ -191,7 +191,7 @@
         <button class="action-btn" id="copyJsonBtn" type="button">⧉ Copy as JSON</button>
         <button class="action-btn" id="referenceBtn" type="button">⚖ Score vs reference…</button>
         <button class="action-btn" id="referenceClearBtn" type="button" hidden>✕ Clear reference</button>
-        <input type="file" id="referenceInput" accept=".csv,.tsv,text/csv,text/tab-separated-values" hidden>
+        <input type="file" id="referenceInput" accept=".csv,.tsv,.json,text/csv,text/tab-separated-values,application/json" hidden>
         <span class="reference-status" id="referenceStatus"></span>
       </div>
 
@@ -241,16 +241,16 @@
 
       <div class="compare-drops">
         <div class="mini-drop" id="dropA" tabindex="0" role="button"
-             aria-label="Upload baseline dataset A (CSV or TSV)">
-          <input type="file" id="fileA" accept=".csv,.tsv,text/csv,text/tab-separated-values" hidden>
+             aria-label="Upload baseline dataset A (CSV, TSV or JSON)">
+          <input type="file" id="fileA" accept=".csv,.tsv,.json,text/csv,text/tab-separated-values,application/json" hidden>
           <span class="mini-drop-tag">A · Baseline</span>
-          <span class="mini-drop-name" id="nameA">Drop CSV/TSV, or <span class="link">browse</span></span>
+          <span class="mini-drop-name" id="nameA">Drop CSV/TSV/JSON, or <span class="link">browse</span></span>
         </div>
         <div class="mini-drop" id="dropB" tabindex="0" role="button"
-             aria-label="Upload current dataset B (CSV or TSV)">
-          <input type="file" id="fileB" accept=".csv,.tsv,text/csv,text/tab-separated-values" hidden>
+             aria-label="Upload current dataset B (CSV, TSV or JSON)">
+          <input type="file" id="fileB" accept=".csv,.tsv,.json,text/csv,text/tab-separated-values,application/json" hidden>
           <span class="mini-drop-tag">B · Current</span>
-          <span class="mini-drop-name" id="nameB">Drop CSV/TSV, or <span class="link">browse</span></span>
+          <span class="mini-drop-name" id="nameB">Drop CSV/TSV/JSON, or <span class="link">browse</span></span>
         </div>
       </div>
       <div class="compare-actions">


### PR DESCRIPTION
## Summary

Add client-side JSON support to the web profiler.

This change adds support for pandas JSON `records` and `split` orientations, introduces a dedicated `parseJSON()` implementation, and routes JSON uploads through it while preserving the existing `{ columns, rows }` interface used by the profiler. CSV/TSV behavior is unchanged, and the reference baseline loader now accepts JSON as well.

Closes #129 