### PR TITLE
Validate audit manifest dataset columns

### DIFF
--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -177,3 +177,10 @@ def test_every_shipped_manifest_loads_without_error(path):
     assert manifest.core_features
     assert manifest.protected_attributes
     assert manifest.random_state == 42   # the pinned reproducibility convention (see MANIFEST_SPEC.md)
+
+    df = pd.read_csv(manifest.dataset_path)
+
+    assert manifest.target.column in df.columns
+
+    for attr in manifest.protected_attributes:
+        assert attr.column in df.columns


### PR DESCRIPTION
## Summary

Validate that every shipped audit manifest references an existing dataset and that its target and protected-attribute columns are present.

## Type

- [ ] Audit
- [ ] Explainer
- [x] Bug fix
- [ ] Other

## Linked issue

Closes #136