### PR TITLE
Add CI automation code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,8 +12,8 @@
 /CONTRIBUTING.md @yakew7
 
 # CI / automation
-/.github/workflows/ @yakew7
-/.github/CODEOWNERS @yakew7
+/.github/workflows/ @yakew7 @ahmdkaml
+/.github/CODEOWNERS @yakew7 @ahmdkaml
 
 # Python packaging
 /pyproject.toml @yakew7


### PR DESCRIPTION
## Summary

Add @ahmdkaml as a CODEOWNER for the CI / automation paths so changes to GitHub workflows and CODEOWNERS are routed to both maintainers for review.

## Type

- [ ] Audit
- [ ] Explainer
- [ ] Bug fix
- [x] Other

## Linked issue

Closes #171 