### PR TITLE
Lazy-load SheetJS for XLSX profiling

### DIFF
--- a/assets/profiler-compare.js
+++ b/assets/profiler-compare.js
@@ -89,16 +89,16 @@
     }
 
     if (/\.xlsx$/i.test(file.name)) {
-      reader.onload = function () {
+      reader.onload = async function () {
         try {
-          applyTable(E.parseXLSX(reader.result));
+          applyTable(await E.parseXLSX(reader.result));
         } catch (err) {
           showError('Could not read dataset ' + key + ': ' + err.message);
         }
       };
       reader.readAsArrayBuffer(file);
     } else {
-      reader.onload = function () {
+      reader.onload = async function () {
         try {
           var text = String(reader.result);
           var table = (/\.json$/i.test(file.name) || file.type === 'application/json')

--- a/assets/profiler-engine.js
+++ b/assets/profiler-engine.js
@@ -264,11 +264,8 @@
   // union-of-columns table builder as parseJSON. SheetJS isn't bundled into
   // this file since it's a large third-party library with its own license -
   // profiler.html loads it from a pinned CDN URL only when needed.
-  function parseXLSX(arrayBuffer) {
-    if (typeof global.XLSX === 'undefined') {
-      throw new Error('The Excel parsing library failed to load (check your network connection), ' +
-        'or use the CLI instead: faircode profile data.xlsx');
-    }
+  async function parseXLSX(arrayBuffer) {
+    await loadSheetJS();  // ensure global.XLSX is present
     var workbook;
     try {
       workbook = global.XLSX.read(arrayBuffer, { type: 'array' });
@@ -281,6 +278,40 @@
     return recordsToTable(records);
   }
 
+  var sheetJsPromise = null;
+
+async function loadSheetJS() {
+  if (global.XLSX) {
+    return Promise.resolve();
+  }
+
+  if (sheetJsPromise) {
+    return sheetJsPromise;
+  }
+
+  sheetJsPromise = new Promise(function (resolve, reject) {
+    var script = document.createElement("script");
+
+    script.src = "https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js";
+    script.integrity = "sha384-vtjasyidUo0kW94K5MXDXntzOJpQgBKXmE7e2Ga4LG0skTTLeBi97eFAXsqewJjw";
+    script.crossOrigin = "anonymous";
+
+    script.onload = function () {
+      resolve();
+    };
+
+    script.onerror = function () {
+      reject(new Error(
+        "The Excel parsing library failed to load (check your network connection), " +
+        "or use the CLI instead: faircode profile data.xlsx"
+      ));
+    };
+
+    document.head.appendChild(script);
+  });
+
+  return sheetJsPromise;
+}
   function isMissing(v) {
     if (v === null || v === undefined) return true;
     return NA_TOKENS.hasOwnProperty(String(v).trim().toLowerCase());

--- a/assets/profiler-ui.js
+++ b/assets/profiler-ui.js
@@ -115,9 +115,9 @@
     var reader = new FileReader();
     reader.onerror = function () { showError('Could not read that file.'); };
     if (/\.xlsx$/i.test(file.name)) {
-      reader.onload = function () {
+      reader.onload = async function () {
         try {
-          runTable(E.parseXLSX(reader.result), file.name);
+          runTable(await E.parseXLSX(reader.result), file.name);
         } catch (err) {
           showError('Could not profile that file: ' + err.message);
         }
@@ -428,9 +428,9 @@
       }
     }
     if (/\.xlsx$/i.test(f.name)) {
-      reader.onload = function () {
+      reader.onload =async function () {
         try {
-          applyReferenceTable(E.parseXLSX(reader.result));
+          applyReferenceTable(await E.parseXLSX(reader.result));
         } catch (err) {
           showError('Could not read reference baseline: ' + err.message);
         }

--- a/profiler.html
+++ b/profiler.html
@@ -280,11 +280,6 @@
     </footer>
   </main>
 
-  <!-- SheetJS (MIT-compatible Apache-2.0 license), pinned version, for client-side .xlsx
-       parsing only - no data is sent anywhere, it just reads bytes already in the browser. -->
-  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"
-          integrity="sha384-vtjasyidUo0kW94K5MXDXntzOJpQgBKXmE7e2Ga4LG0skTTLeBi97eFAXsqewJjw"
-          crossorigin="anonymous"></script>
   <script src="assets/profiler-engine.js"></script>
   <script src="assets/profiler-ui.js"></script>
   <script src="assets/profiler-compare.js"></script>

--- a/scripts/engine-js.js
+++ b/scripts/engine-js.js
@@ -75,16 +75,17 @@ async function main() {
     const E = loadEngine();
     const buf = fs.readFileSync(args[0]);
     const arrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
-    process.stdout.write(JSON.stringify(E.profile(E.parseXLSX(arrayBuffer))));
+    const table = await E.parseXLSX(arrayBuffer);
+    process.stdout.write(JSON.stringify(E.profile(table)));
     return;
   }
 
   if (command === "compare" && args.length === 2) {
     const E = loadEngine();
     const [pathA, pathB] = args;
-    const resultA = E.profile(E.parseCSV(fs.readFileSync(pathA, "utf8")));
-    const resultB = E.profile(E.parseCSV(fs.readFileSync(pathB, "utf8")));
-    const cmp = E.compare(resultA, resultB, path.basename(pathA), path.basename(pathB));
+    const resultA = await E.profile(await E.parseCSV(fs.readFileSync(pathA, "utf8")));
+    const resultB = await E.profile(await E.parseCSV(fs.readFileSync(pathB, "utf8")));
+    const cmp = await E.compare(resultA, resultB, path.basename(pathA), path.basename(pathB));
     process.stdout.write(JSON.stringify(cmp));
     return;
   }


### PR DESCRIPTION
Closes #190.

## Summary

- Remove the unconditional SheetJS `<script>` from `profiler.html`.
- Lazy-load SheetJS the first time an `.xlsx` file is opened.
- Make the XLSX parsing path asynchronous and update all callers accordingly.
- Preserve the existing pinned CDN URL, SRI hash, and error handling.

This avoids downloading and parsing the ~880 KB SheetJS bundle for users who only profile CSV/TSV/JSON datasets, while keeping XLSX support unchanged once requested.