### PR TITLE
Check figure filename drift in results workflow

### DIFF
--- a/.github/workflows/results-drift.yml
+++ b/.github/workflows/results-drift.yml
@@ -33,3 +33,19 @@ jobs:
             exit 1
           fi
           echo "results/*.csv matches paper/results-frozen/*.csv."
+      - name: Check figure filenames
+        run: |
+          set -euo pipefail
+
+          find results/figures -maxdepth 1 -type f -printf "%f\n" \
+            | sort > /tmp/results_figures.txt
+
+          find paper/results-frozen/figures -maxdepth 1 -type f -printf "%f\n" \
+            | sort > /tmp/frozen_figures.txt
+
+          if ! diff -u /tmp/results_figures.txt /tmp/frozen_figures.txt; then
+            echo "::error::Figure filenames differ between results/figures and paper/results-frozen/figures."
+            exit 1
+          fi
+
+          echo "Figure filenames match."


### PR DESCRIPTION
## Summary

- Add a workflow check that compares the filenames in `results/figures/` and `paper/results-frozen/figures/`
- Detect added, removed, or renamed figures without comparing image contents

Closes #186