### PR TITLE
Show ignored XLSX sheets in web UI

### DIFF
--- a/assets/profiler-compare.js
+++ b/assets/profiler-compare.js
@@ -100,7 +100,7 @@
 
           if (result.ignoredSheets.length > 0) {
             statusEl.textContent =
-              'Read sheet "' + result.sheetName + '" — ' +
+              'Read sheet "' + result.sheetName + '" - ' +
               result.ignoredSheets.length + ' other sheet(s) ignored.';
             statusEl.hidden = false;
           } else {

--- a/assets/profiler-compare.js
+++ b/assets/profiler-compare.js
@@ -20,6 +20,8 @@
   var nameBEl = document.getElementById('nameB');
   var sampleBtn = document.getElementById('compareSampleBtn');
   var errorEl = document.getElementById('compareError');
+  var fileStatusA = document.getElementById('statusA');
+  var fileStatusB = document.getElementById('statusB');
   var resultsEl = document.getElementById('compareResults');
   var announcer = document.getElementById('compareAnnouncer');
   var reportActionsEl = document.getElementById('compareReportActions');
@@ -72,6 +74,7 @@
   }
 
   function readFile(key, file, drop, nameEl) {
+    var statusEl = key === 'A' ? fileStatusA : fileStatusB;
     var okExt = /\.(csv|tsv|json|xlsx)$/i.test(file.name);
     var okType = file.type === 'text/csv' || file.type === 'text/tab-separated-values' ||
       file.type === 'application/json' ||
@@ -91,7 +94,20 @@
     if (/\.xlsx$/i.test(file.name)) {
       reader.onload = async function () {
         try {
-          applyTable(await E.parseXLSX(reader.result));
+          var result = await E.parseXLSX(reader.result);
+
+          applyTable(result.table);
+
+          if (result.ignoredSheets.length > 0) {
+            statusEl.textContent =
+              'Read sheet "' + result.sheetName + '" — ' +
+              result.ignoredSheets.length + ' other sheet(s) ignored.';
+            statusEl.hidden = false;
+          } else {
+            statusEl.textContent =
+              'Read sheet "' + result.sheetName + '".';
+            statusEl.hidden = false;
+          }
         } catch (err) {
           showError('Could not read dataset ' + key + ': ' + err.message);
         }

--- a/assets/profiler-engine.js
+++ b/assets/profiler-engine.js
@@ -275,7 +275,7 @@
     }
 
     var sheetName = workbook.SheetNames[0];
-    if (!sheetName) return { columns: [], rows: [] };
+    if (!sheetName) return { table: { columns: [], rows: [] }, ignoredSheets: [], sheetName: null };
 
     var sheet = workbook.Sheets[sheetName];
     var records = global.XLSX.utils.sheet_to_json(sheet, { defval: null, raw: true });
@@ -289,10 +289,10 @@
       var columns = headerRow.map(function (h) {
         return h === null || h === undefined ? '' : String(h);
       });
-      return { columns: columns, rows: [] };
+      return { table: { columns: columns, rows: [] }, ignoredSheets: workbook.SheetNames.slice(1), sheetName: sheetName };
     }
 
-    return recordsToTable(records);
+    return { table: recordsToTable(records), ignoredSheets: workbook.SheetNames.slice(1), sheetName: sheetName };
   }
 
   var sheetJsPromise = null;

--- a/assets/profiler-ui.js
+++ b/assets/profiler-ui.js
@@ -124,7 +124,7 @@
 
         if (result.ignoredSheets.length > 0) {
           fileStatus.textContent =
-          'Reading sheet "' + result.sheetName + '" — ' +
+          'Reading sheet "' + result.sheetName + '" - ' +
           result.ignoredSheets.length + ' other sheet(s) ignored.';
           fileStatus.hidden = false;
         }

--- a/assets/profiler-ui.js
+++ b/assets/profiler-ui.js
@@ -15,6 +15,7 @@
   var fileInput = document.getElementById('fileInput');
   var sampleBtn = document.getElementById('sampleBtn');
   var errorEl = document.getElementById('error');
+  var fileStatus = document.getElementById('fileStatus');
   var results = document.getElementById('results');
   var downloadHtmlBtn = document.getElementById('downloadHtmlBtn');
   var copyJsonBtn = document.getElementById('copyJsonBtn');
@@ -116,12 +117,21 @@
     reader.onerror = function () { showError('Could not read that file.'); };
     if (/\.xlsx$/i.test(file.name)) {
       reader.onload = async function () {
-        try {
-          runTable(await E.parseXLSX(reader.result), file.name);
-        } catch (err) {
-          showError('Could not profile that file: ' + err.message);
+      try {
+        var result = await E.parseXLSX(reader.result);
+
+        runTable(result.table, file.name);
+
+        if (result.ignoredSheets.length > 0) {
+          fileStatus.textContent =
+          'Reading sheet "' + result.sheetName + '" — ' +
+          result.ignoredSheets.length + ' other sheet(s) ignored.';
+          fileStatus.hidden = false;
         }
-      };
+      } catch (err) {
+        showError('Could not profile that file: ' + err.message);
+      }
+    };
       reader.readAsArrayBuffer(file);
     } else {
       reader.onload = function () { runText(String(reader.result), file.name); };
@@ -417,20 +427,34 @@
     if (!f) return;
     var reader = new FileReader();
     reader.onerror = function () { showError('Could not read the reference file.'); };
-    function applyReferenceTable(table) {
-      try {
-        currentOpts.reference = E.parseReference(table);
+    function applyReferenceTable(table, sheetInfo) {
+    try {
+      currentOpts.reference = E.parseReference(table);
+
+      if (sheetInfo && sheetInfo.ignoredSheets.length > 0) {
+        referenceStatus.textContent =
+          '⚖ scored vs ' + f.name +
+          ' — read sheet "' + sheetInfo.sheetName + '" — ' +
+          sheetInfo.ignoredSheets.length + ' other sheet(s) ignored';
+      } else if (sheetInfo) {
+        referenceStatus.textContent =
+          '⚖ scored vs ' + f.name +
+          ' — read sheet "' + sheetInfo.sheetName + '"';
+      } else {
         referenceStatus.textContent = '⚖ scored vs ' + f.name;
-        referenceClearBtn.hidden = false;
-        reprofile(false);
-      } catch (err) {
-        showError('Could not read reference baseline: ' + err.message);
       }
+      referenceStatus.hidden = false;
+      referenceClearBtn.hidden = false;
+      reprofile(false);
+    } catch (err) {
+      showError('Could not read reference baseline: ' + err.message);
+    }
     }
     if (/\.xlsx$/i.test(f.name)) {
       reader.onload = async function () {
         try {
-          applyReferenceTable(await E.parseXLSX(reader.result));
+          var result = await E.parseXLSX(reader.result);
+          applyReferenceTable(result.table, result);
         } catch (err) {
           showError('Could not read reference baseline: ' + err.message);
         }

--- a/assets/profiler-ui.js
+++ b/assets/profiler-ui.js
@@ -434,12 +434,12 @@
       if (sheetInfo && sheetInfo.ignoredSheets.length > 0) {
         referenceStatus.textContent =
           '⚖ scored vs ' + f.name +
-          ' — read sheet "' + sheetInfo.sheetName + '" — ' +
+          ' - read sheet "' + sheetInfo.sheetName + '" - ' +
           sheetInfo.ignoredSheets.length + ' other sheet(s) ignored';
       } else if (sheetInfo) {
         referenceStatus.textContent =
           '⚖ scored vs ' + f.name +
-          ' — read sheet "' + sheetInfo.sheetName + '"';
+          ' - read sheet "' + sheetInfo.sheetName + '"';
       } else {
         referenceStatus.textContent = '⚖ scored vs ' + f.name;
       }

--- a/profiler.html
+++ b/profiler.html
@@ -174,6 +174,7 @@
       </div>
     </section>
 
+    <p class="profiler-status" id="fileStatus" aria-live="polite" hidden></p>
     <p class="profiler-error" id="error" role="alert" hidden></p>
     <p class="sr-only" id="resultsAnnouncer" aria-live="polite" aria-atomic="true"></p>
 
@@ -250,12 +251,14 @@
           <input type="file" id="fileA" accept=".csv,.tsv,.json,.xlsx,text/csv,text/tab-separated-values,application/json,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" hidden>
           <span class="mini-drop-tag">A · Baseline</span>
           <span class="mini-drop-name" id="nameA">Drop CSV/TSV/JSON/XLSX, or <span class="link">browse</span></span>
+          <span class="mini-drop-status" id="statusA" aria-live="polite"></span>
         </div>
         <div class="mini-drop" id="dropB" tabindex="0" role="button"
              aria-label="Upload current dataset B (CSV, TSV, JSON, or Excel)">
           <input type="file" id="fileB" accept=".csv,.tsv,.json,.xlsx,text/csv,text/tab-separated-values,application/json,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" hidden>
           <span class="mini-drop-tag">B · Current</span>
           <span class="mini-drop-name" id="nameB">Drop CSV/TSV/JSON/XLSX, or <span class="link">browse</span></span>
+          <span class="mini-drop-status" id="statusB" aria-live="polite"></span>
         </div>
       </div>
       <div class="compare-actions">


### PR DESCRIPTION
What changed
parseXLSX() now returns the selected sheet name and any additional sheets that were ignored alongside the parsed table.
The main profiler displays the sheet that was read and warns when additional sheets were ignored.
The compare A/B uploads surface the same information for each dataset.
The reference baseline upload also reports the sheet that was read and any ignored sheets.
Existing XLSX parsing behavior remains unchanged; this only surfaces information that was previously hidden.
Scope

This PR is UI-only for #182. The CLI output still needs to be implemented separately.

Related to #182.