### PR TITLE
Report ignored XLSX sheets in CLI

### DIFF
--- a/scripts/engine-js.js
+++ b/scripts/engine-js.js
@@ -75,7 +75,8 @@ async function main() {
     const E = loadEngine();
     const buf = fs.readFileSync(args[0]);
     const arrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
-    const table = await E.parseXLSX(arrayBuffer);
+    const result = await E.parseXLSX(arrayBuffer);
+    const table = result.table;
     process.stdout.write(JSON.stringify(E.profile(table)));
     return;
   }


### PR DESCRIPTION
This change keeps engine.js on its original profiling flow despite the new parseXLSX() return shape. The parser now returns the table together with sheet metadata, so the CLI bridge needs to pass result.table into E.profile() rather than the wrapper object.

I’ll handle the actual CLI sheet-name/ignored-sheet reporting separately afterward.