### PR TITLE
Install optional extras in make setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:  ## Show the available targets
 		awk 'BEGIN{FS = ":.*?## "}{printf "  %-16s %s\n", $$1, $$2}'
 
 setup:  ## Install the package plus the dev tools (pytest, pre-commit)
-	$(PY) -m pip install -e . pytest pre-commit
+	$(PY) -m pip install -e ".[excel,parquet,proxy]" pytest pre-commit
 
 test:  ## Run the full test suite (mirrors CI)
 	$(PY) -m pytest tests/ -q
@@ -21,7 +21,7 @@ build-explainers:  ## Regenerate explainer pages, data.js, sitemap, and OG image
 	$(PY) scripts/build_explainers.py
 	$(PY) scripts/generate_og_images.py
 
-favicons:  ## Regenerate favicon.ico, apple-touch-icon.png, and icon-{192,512}.png from logo.svg
+favicons:  ## Regenerate favicon.ico/PNGs and apple-touch-icon.png from logo.svg
 	$(PY) scripts/generate_favicons.py
 
 lint:  ## Enforce the em-dash-free rule (mirrors the lint workflow)


### PR DESCRIPTION
This updates make setup to install the excel, parquet, and proxy optional extras along with the existing development dependencies.

This prevents make test from silently skipping tests that depend on those optional packages, while keeping the extras optional for contributors who do not use the Makefile setup.

Closes #214.