### PR TITLE
Validate CITATION.cff in CI

### DIFF
--- a/.github/workflows/citation.yml
+++ b/.github/workflows/citation.yml
@@ -1,0 +1,22 @@
+name: Validate CITATION.cff
+
+on:
+  push:
+    paths:
+      - CITATION.cff
+  pull_request:
+    paths:
+      - CITATION.cff
+
+jobs:
+  validate:
+    name: Validate CITATION.cff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Validate CITATION.cff
+        uses: citation-file-format/cffconvert-github-action@2.0.0
+        with:
+          args: "--validate"


### PR DESCRIPTION
Adds a dedicated CI workflow to validate CITATION.cff against the CFF schema using the official cffconvert action. The workflow only runs when CITATION.cff is changed.

Closes #221.