### PR TITLE
Test locked dependency versions against minimums

### DIFF
--- a/tests/test_dependency_versions.py
+++ b/tests/test_dependency_versions.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import re
+
+
+def version_tuple(version):
+    return tuple(int(part) for part in version.split("."))
+
+
+def normalize_dependency(name):
+    return name.lower().replace("-", "_").replace(".", "_")
+
+
+def test_requirements_lock_versions_satisfy_pyproject_minimums():
+    root = Path(__file__).resolve().parents[1]
+
+    pyproject = root / "pyproject.toml"
+    requirements_lock = root / "requirements-lock.txt"
+
+    assert pyproject.is_file(), f"Could not find {pyproject}"
+    assert requirements_lock.is_file(), f"Could not find {requirements_lock}"
+
+    pyproject_text = pyproject.read_text(encoding="utf-8")
+    lock_text = requirements_lock.read_text(encoding="utf-8")
+
+    pyproject_versions = {
+        normalize_dependency(name): version
+        for name, version in re.findall(
+            r'([A-Za-z0-9_.-]+)\s*>=\s*([0-9]+(?:\.[0-9]+)*)',
+            pyproject_text,
+        )
+    }
+
+    locked_versions = {
+        normalize_dependency(name): version
+        for name, version in re.findall(
+            r'^([A-Za-z0-9_.-]+)==([0-9]+(?:\.[0-9]+)*)',
+            lock_text,
+            re.MULTILINE,
+        )
+    }
+
+    for dependency, minimum in pyproject_versions.items():
+        locked = locked_versions.get(dependency)
+
+        if locked is None:
+            continue
+
+        assert version_tuple(locked) >= version_tuple(minimum), (
+            f"{dependency} is locked to {locked}, "
+            f"but pyproject.toml requires >= {minimum}"
+        )


### PR DESCRIPTION
Adds a dependency-version consistency test comparing requirements-lock.txt pins against pyproject.toml minimum versions.

The test currently catches the existing scikit-learn drift (1.8.0 locked vs >=1.9.0 declared), as intended.

Closes #215.