### PR TITLE
Document proxy hints in web profiler

### DIFF
--- a/profiler.html
+++ b/profiler.html
@@ -175,7 +175,8 @@
         <p class="dropzone-title">Drop a CSV, TSV, JSON, or Excel file here, or <span class="link">browse</span></p>
         <p class="dropzone-hint" id="dropzoneHint">Comma- or tab-separated values with a header row, JSON
         (records or split orientation), or an .xlsx workbook (first sheet). (Parquet files: use
-        <code>faircode profile data.parquet</code> from the CLI.)</p>
+        <code>faircode profile data.parquet</code> from the CLI.) Proxy-hint detection: use
+        <code>faircode profile --proxy-hints</code> from the CLI.</p>
         <button class="sample-btn" id="sampleBtn" type="button">Try it with a sample dataset</button>
       </div>
     </section>


### PR DESCRIPTION
Adds a short CLI-only note for --proxy-hints to the web profiler copy, improving feature discoverability.

Closes #217.