### PR TITLE
test locked dependency versions against minimums

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 excel = ["openpyxl>=3.0"]
 parquet = ["pyarrow>=10.0"]
 proxy = ["scipy>=1.10"]
-benchmark = ["scikit-learn>=1.9.0", "pyyaml>=6.0", "fairlearn>=0.14.0", "matplotlib>=3.11"]
+benchmark = ["scikit-learn>=1.8.0", "pyyaml>=6.0", "fairlearn>=0.14.0", "matplotlib>=3.11"]
 
 [project.urls]
 Homepage = "https://github.com/yakew7/Fair-Code"

--- a/tests/test_dependency_versions.py
+++ b/tests/test_dependency_versions.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import re
+
+
+def test_requirements_lock_versions_satisfy_pyproject_minimums():
+    root = Path(__file__).resolve().parents[1]
+
+    pyproject = root / "pyproject.toml"
+    requirements_lock = root / "requirements-lock.txt"
+
+    assert pyproject.is_file(), f"Could not find {pyproject}"
+    assert requirements_lock.is_file(), f"Could not find {requirements_lock}"
+
+    pyproject_text = pyproject.read_text(encoding="utf-8")
+    lock_text = requirements_lock.read_text(encoding="utf-8")
+
+    pyproject_versions = dict(
+        re.findall(
+            r'([A-Za-z0-9_.-]+)\s*>=\s*([0-9]+(?:\.[0-9]+)*)',
+            pyproject_text,
+        )
+    )
+
+    locked_versions = dict(
+        re.findall(
+            r'^([A-Za-z0-9_.-]+)==([0-9]+(?:\.[0-9]+)*)',
+            lock_text,
+            re.MULTILINE,
+        )
+    )
+
+    for dependency, minimum in pyproject_versions.items():
+        locked = locked_versions.get(dependency)
+
+        dependency = normalize_dependency(dependency)
+
+        if locked is None:
+            continue
+
+        assert version_tuple(locked) >= version_tuple(minimum), (
+            f"{dependency} is locked to {locked}, "
+            f"but pyproject.toml requires >= {minimum}"
+        )
+
+
+def version_tuple(version):
+    return tuple(int(part) for part in version.split("."))
+
+
+def normalize_dependency(name):
+    return name.lower().replace("-", "_").replace(".", "_")


### PR DESCRIPTION
Adds the dependency-version consistency test from #215 and resolves the drift it detects.

- Restore `tests/test_dependency_versions.py`
- Check locked versions against `pyproject.toml` minimums
- Lower the `scikit-learn` minimum from `1.9.0` to `1.8.0` to match the frozen lock file

The frozen `requirements-lock.txt` is left unchanged.

Closes #255 