### PR TITLE
Add test coverage reporting

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -120,6 +120,10 @@ jobs:
 
       - name: Run profiler tests
         run: make test
+        
+      - name: Report test coverage
+        run: make coverage
+        continue-on-error: true
 
       - name: Smoke-test the CLI
         run: |


### PR DESCRIPTION
Add a non-gating coverage report to the profiler test workflow, using the new make coverage target.

closes #249 