### PR TITLE
Enhance tests for SVG logo parsing

### DIFF
--- a/tests/test_generate_images.py
+++ b/tests/test_generate_images.py
@@ -1,8 +1,81 @@
 import importlib
 
+import pytest
 from PIL import Image
 import json
 import shutil
+
+_VALID_SVG = """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="32" y="18" width="13" height="64" fill="#14171A"/>
+  <rect x="32" y="18" width="42" height="13" fill="#14171A"/>
+  <rect x="32" y="44" width="36" height="13" fill="#4F7A5B"/>
+</svg>
+"""
+
+
+def test_parse_mark_accepts_the_real_logo_svg():
+    script = importlib.import_module("scripts.generate_favicons")
+
+    spec = script._parse_mark(script.ROOT / "assets" / "icons" / "logo.svg")
+
+    assert spec["size"] == 100.0
+    assert spec["mark_fill"] == "#14171A"
+    assert spec["accent_fill"] == "#4F7A5B"
+
+
+def test_parse_mark_rejects_non_square_viewbox(tmp_path):
+    script = importlib.import_module("scripts.generate_favicons")
+    bad_svg = tmp_path / "bad.svg"
+    bad_svg.write_text(
+        _VALID_SVG.replace('viewBox="0 0 100 100"', 'viewBox="0 0 100 80"'),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="expected a square viewBox starting at 0,0"):
+        script._parse_mark(bad_svg)
+
+
+def test_parse_mark_rejects_viewbox_not_at_origin(tmp_path):
+    script = importlib.import_module("scripts.generate_favicons")
+    bad_svg = tmp_path / "bad.svg"
+    bad_svg.write_text(
+        _VALID_SVG.replace('viewBox="0 0 100 100"', 'viewBox="10 0 100 100"'),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="expected a square viewBox starting at 0,0"):
+        script._parse_mark(bad_svg)
+
+
+def test_parse_mark_rejects_a_fourth_rect(tmp_path):
+    script = importlib.import_module("scripts.generate_favicons")
+    bad_svg = tmp_path / "bad.svg"
+    bad_svg.write_text(
+        _VALID_SVG.replace(
+            "</svg>",
+            '  <rect x="0" y="0" width="10" height="10" fill="#000000"/>\n</svg>',
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="no longer exactly three rects"):
+        script._parse_mark(bad_svg)
+
+
+def test_parse_mark_rejects_mismatched_stem_and_bar_fill(tmp_path):
+    script = importlib.import_module("scripts.generate_favicons")
+    bad_svg = tmp_path / "bad.svg"
+    bad_svg.write_text(
+        _VALID_SVG.replace(
+            '<rect x="32" y="18" width="42" height="13" fill="#14171A"/>',
+            '<rect x="32" y="18" width="42" height="13" fill="#000000"/>',
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="stem and top bar are expected to share one fill color"):
+        script._parse_mark(bad_svg)
+
 
 def test_generate_favicons(tmp_path):
     script = importlib.import_module("scripts.generate_favicons")


### PR DESCRIPTION
Add test coverage for generate_favicons.py's malformed-logo.svg error paths

_parse_mark()'s three ValueError branches (non-square/off-origin
viewBox, wrong rect count, mismatched stem/bar fill) had no test
covering them - only the happy path was exercised. Adds one test
per branch plus a baseline check that the real logo.svg still
parses, closes #245.