### PR TITLE
Add matplotlib to the benchmark extra's docstring/README package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -979,7 +979,7 @@ them:
 | **Intersectional gaps** | For every pair of declared protected attributes, via `faircode.significance.intersectional_report` |
 
 ```bash
-pip install -e ".[benchmark]"                      # scikit-learn + pyyaml + fairlearn
+pip install -e ".[benchmark]"                      # scikit-learn + pyyaml + fairlearn + matplotlib
 faircode benchmark                                  # discovers every */audit.yaml, writes results/
 faircode benchmark --out results/ --n-resamples 2000 --n-permutations 2000
 faircode benchmark COMPAS/audit.yaml                # run a subset explicitly

--- a/faircode/cli.py
+++ b/faircode/cli.py
@@ -19,7 +19,7 @@ Reading .xlsx additionally requires the optional 'openpyxl' extra
 (`pip install faircode[excel]`); reading .parquet additionally requires the
 optional 'pyarrow' extra (`pip install faircode[parquet]`). The `benchmark`
 command additionally requires the optional 'benchmark' extra
-(`pip install faircode[benchmark]`: scikit-learn + pyyaml + fairlearn).
+(`pip install faircode[benchmark]`: scikit-learn + pyyaml + fairlearn + matplotlib).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
pyproject.toml's benchmark extra gained matplotlib in #235 (figures.py
needs it to render strategy-comparison PNGs), but cli.py's module
docstring and README's install snippet still listed the old three
packages. Closes #244.
