### PR TITLE
docs: add missing trigger paths to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ Optionally install the git hooks so the checks run automatically:
 ```bash
 pre-commit install
 ```
-With the hooks installed, the em-dash lint runs on every commit (and explainer pages rebuild when you touch `explainers/*.md`), while the full test suite runs on `git push` - but only when the push actually touches something the suite covers (`faircode/`, `scripts/`, `tests/`, a dataset CSV, an audit's `fair.py`/`unfair.py`, `pyproject.toml`, `requirements*.txt`, or `.github/CODEOWNERS`). A prose-only push (docs, `README.md`, `explainers/*.md`, website copy) skips it entirely. When it does run, expect several seconds to tens of seconds because it includes the benchmark tests. Run `make check` any time to reproduce CI on demand regardless of what changed.
+With the hooks installed, the em-dash lint runs on every commit (and explainer pages rebuild when you touch `explainers/*.md`), while the full test suite runs on `git push` - but only when the push actually touches something the suite covers (`faircode/`, `scripts/`, `tests/`, a dataset CSV, an audit's `fair.py`/`unfair.py`/`audit.yaml`, `pyproject.toml`, `requirements*.txt`, `assets/profiler-engine.js`, `assets/profiler-compare.js`, or `.github/CODEOWNERS`). A prose-only push (docs, `README.md`, `explainers/*.md`, website copy) skips it entirely. When it does run, expect several seconds to tens of seconds because it includes the benchmark tests. Run `make check` any time to reproduce CI on demand regardless of what changed.
 
 ---
 


### PR DESCRIPTION
Add `assets/profiler-engine.js`, `assets/profiler-compare.js`, and `audit.yaml` to the pre-push trigger-path list to match the actual regex in `.pre-commit-config.yaml`.

Closes #285