### PR TITLE
Update cli.py

### DIFF
--- a/faircode/cli.py
+++ b/faircode/cli.py
@@ -104,7 +104,7 @@ def main(argv: list[str] | None = None) -> int:
                    help="imbalance-ratio flag threshold (default 3.0)")
     p.add_argument("--missing-flag", type=float, metavar="F",
                    help="missing-data flag threshold (default 0.05)")
-    p.add_argument("--min-group-size", type=int, default=100, metavar="N",
+    p.add_argument("--min-group-size", type=int, metavar="N",
                    help="warn when a subgroup has fewer than N rows (default: 100)")
 
     c = sub.add_parser("compare",
@@ -126,7 +126,7 @@ def main(argv: list[str] | None = None) -> int:
                    help="imbalance-ratio flag threshold (default 3.0)")
     c.add_argument("--missing-flag", type=float, metavar="F",
                    help="missing-data flag threshold (default 0.05)")
-    c.add_argument("--min-group-size", type=int, default=100, metavar="N",
+    c.add_argument("--min-group-size", type=int, metavar="N",
                    help="warn when a subgroup has fewer than N rows (default: 100)")
     c.add_argument("--fail-on-drift", action="store_true",
                    help="exit 1 when any dimension shows drift or the overall score drops")


### PR DESCRIPTION
Add proxy extra to CI, stop hardcoding --min-group-size's default

audits.yml's profiler job never installed the proxy extra, so
tests/test_proxy.py's scipy-gated tests were silently skipped in CI
(closes #298) - verified locally that they actually run once scipy
is present.

--min-group-size hardcoded default=100 in argparse instead of
deferring to profiler.MIN_GROUP_SIZE like every sibling threshold
flag already does, so a future tune of that constant would silently
not reach the CLI (closes #299 ). Confirmed the resolved default is
still 100 via _resolve_opts's fallback.
