### PR TITLE
Report ignored .xlsx sheets for both files in faircode compare

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@
 /assets/profiler-engine.js @yakew7 @ahmdkaml
 /assets/profiler-compare.js @yakew7 @ahmdkaml
 /assets/profiler-ui.js @yakew7 @ahmdkaml
+/assets/profiler.css @yakew7 @ahmdkaml
 /profiler.html @yakew7 @ahmdkaml
 /index.html @yakew7
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,6 +17,8 @@ body:
         - German Credit Lending
         - Insurance Denial
         - Benefits Denial
+        - Healthcare Readmission
+        - Tenant Screening
         - Notebook (specify below)
         - Other (specify below)
     validations:

--- a/README.md
+++ b/README.md
@@ -1070,7 +1070,7 @@ never displaces `v2.0.0`. Under the freeze it stays fixed until the paper is pub
 - [x] Insurance Denial - Healthcare Bias
 - [x] Benefits Denial - Welfare Eligibility Bias
 - [x] Healthcare Readmission - Clinical Bias
-- [x] Jupyter notebook walkthroughs for all five audits
+- [x] Jupyter notebook walkthroughs for each audit
 - [x] CI pipeline - all audit scripts run automatically on every push and PR
 - [x] Explainer: Proxy Variables
 - [x] Explainer: Equalized Odds

--- a/faircode/cli.py
+++ b/faircode/cli.py
@@ -226,9 +226,23 @@ def main(argv: list[str] | None = None) -> int:
             "missing_flag": args.missing_flag,
             "min_group_size": args.min_group_size,
         }
+        df_a = _read_or_exit(args.csv_a)
+        df_b = _read_or_exit(args.csv_b)
+
+        for path in (args.csv_a, args.csv_b):
+            sheet_info = get_xlsx_sheet_info(path)
+            if sheet_info is not None:
+                sheet_name, ignored_sheets = sheet_info
+                if ignored_sheets:
+                    print(
+                        f"{path}: read sheet '{sheet_name}' - {len(ignored_sheets)} "
+                        f"other sheet(s) ignored.",
+                        file=sys.stderr,
+                    )
+
         result = compare(
-            profile(_read_or_exit(args.csv_a), overrides, opts),
-            profile(_read_or_exit(args.csv_b), overrides, opts),
+            profile(df_a, overrides, opts),
+            profile(df_b, overrides, opts),
             name_a=args.csv_a, name_b=args.csv_b,
         )
         if args.html:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -328,6 +328,57 @@ def test_profile_xlsx_single_sheet_stays_silent(tmp_path, capsys):
     assert "ignored" not in captured.err
 
 
+def _make_multi_sheet_xlsx(path, sex_values):
+    import openpyxl
+
+    wb = openpyxl.Workbook()
+    first = wb.active
+    first.title = "Data"
+    first.append(["sex"])
+    for value in sex_values:
+        first.append([value])
+    wb.create_sheet("Notes")
+    wb.create_sheet("Extra")
+    wb.save(path)
+
+
+@requires_openpyxl
+def test_compare_xlsx_reports_ignored_sheets_for_both_files(tmp_path, capsys):
+    path_a = tmp_path / "a.xlsx"
+    path_b = tmp_path / "b.xlsx"
+    _make_multi_sheet_xlsx(path_a, ["M", "F"])
+    _make_multi_sheet_xlsx(path_b, ["M", "M"])
+
+    exit_code = main(["compare", str(path_a), str(path_b)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert f"{path_a}: read sheet 'Data' - 2 other sheet(s) ignored." in captured.err
+    assert f"{path_b}: read sheet 'Data' - 2 other sheet(s) ignored." in captured.err
+
+
+@requires_openpyxl
+def test_compare_xlsx_single_sheet_stays_silent(tmp_path, capsys):
+    import openpyxl
+
+    path_a = tmp_path / "a.xlsx"
+    path_b = tmp_path / "b.xlsx"
+    for path, sex_values in ((path_a, ["M", "F"]), (path_b, ["M", "M"])):
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "Data"
+        ws.append(["sex"])
+        for value in sex_values:
+            ws.append([value])
+        wb.save(path)
+
+    exit_code = main(["compare", str(path_a), str(path_b)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "ignored" not in captured.err
+
+
 # ── Benchmark subcommand tests ────────────────────────────────────────────────
 
 def test_cli_benchmark_import_error_message(monkeypatch, capsys):


### PR DESCRIPTION
Report ignored .xlsx sheets for both files in faircode compare

faircode profile already prints a note when an .xlsx has sheets
besides the one actually read; compare silently profiled sheet 0
of each workbook with no indication others existed - misleading
when a drift report is actually comparing the wrong tabs.

Closes #300
Closes #308 
Closes #307 
Closes #310 