### PR TITLE
Record dataset hash, version and resolved params on the JSON export

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,12 +942,19 @@ faircode profile data.csv --cross race,age         # choose the intersection pai
 faircode profile data.csv --reference census.csv   # score vs a population baseline
 faircode profile data.csv --proxy-hints            # chi-squared proxy hints (needs scipy)
 faircode profile data.csv --min-share 0.1          # tune the flagging thresholds
+faircode profile data.csv --json --no-provenance   # drop the run-metadata block
 ```
 
 For CI, `--fail-under N` returns exit code `1` and explains the failing score
 on stderr when the overall representation score is below `N`; report output,
 including `--json`, remains on stdout. A score at or above the threshold exits
 successfully.
+
+`--json` output carries a `provenance` block recording the SHA-256 of the input
+file, the `faircode` version, and the thresholds actually resolved for the run,
+so an exported report can be tied back to what produced it - see
+[faircode/SPEC.md](faircode/SPEC.md#10-export-provenance). It is derived purely
+from the inputs, so `--json` stays reproducible; `--no-provenance` omits it.
 
 The engine is domain-agnostic - it works on any tabular CSV (health, hiring, lending, justice),
 auto-detecting demographic columns (sex, race, age, geography) by name. Beyond the single-dataset

--- a/faircode/SPEC.md
+++ b/faircode/SPEC.md
@@ -15,7 +15,7 @@ before any model is trained. It does not train models, drop columns, or measure 
 that is what the `unfair.py` / `fair.py` audits do. The Profiler answers a different question:
 **"who is, and is not, adequately represented in this data?"**
 
-[1. Detection](#1-column-auto-detection) · [2. Age](#2-age-normalization) · [3. Metrics](#3-per-dimension-metrics) · [4. Intersections](#4-intersectional-gaps-informational-not-scored) · [5. Score](#5-headline-score--grade) · [6. Shape](#6-result-shape) · [7. Defaults](#7-defaults-single-place-to-tune) · [8. Comparison](#8-dataset-comparison-representation-drift) · [9. Reference](#9-reference-baseline)
+[1. Detection](#1-column-auto-detection) · [2. Age](#2-age-normalization) · [3. Metrics](#3-per-dimension-metrics) · [4. Intersections](#4-intersectional-gaps-informational-not-scored) · [5. Score](#5-headline-score--grade) · [6. Shape](#6-result-shape) · [7. Defaults](#7-defaults-single-place-to-tune) · [8. Comparison](#8-dataset-comparison-representation-drift) · [9. Reference](#9-reference-baseline) · [10. Provenance](#10-export-provenance)
 
 </div>
 
@@ -290,3 +290,52 @@ unchanged.
   "groups": [ { "label": "White", "expected": 0.60, "actual": 0.80, "delta": 0.20 } ]
 }
 ```
+
+---
+
+## 10. Export provenance
+
+Sections 1-9 describe *what the numbers are*. This section describes *what produced them*, so an
+exported report can be tied back to its run. Without it a pasted result cannot be checked: the same
+CSV scores differently under a different `--map`, a different `--min-share`, or a different
+reference baseline, and none of that is visible in the result shape of section 6.
+
+**The block is attached at the export boundary, not inside `profile()`/`compare()`.** The two
+engines are compared with `==` in `tests/test_js_parity.py`, so a local file name cannot live in the
+result. `report.to_json(result, provenance=...)` adds it in Python; the web export adds the same
+field names in `copyResultAsJSON()`. Section 6's shape is unchanged, and the parity test needs no
+edit.
+
+```jsonc
+"provenance": {
+  "faircode_version": "2.0.0",
+  "engine": "python",                       // or "js"
+  "dataset_hash": "sha256:9f86d081884c7d65...",
+  "params": { "cross": null, "imbalance_flag": 3.0, "intersection_floor": 0.01,
+              "min_group_size": 100, "min_share": 0.05, "missing_flag": 0.05,
+              "reference_flag": 0.05 },
+  "overrides": { "gndr": "sex" }
+}
+```
+
+- **`dataset_hash`** - lowercase hex of the SHA-256 over the **raw file bytes**, prefixed with the
+  algorithm. Raw bytes, not the parsed frame: `hashlib.sha256().hexdigest()` and
+  `crypto.subtle.digest('SHA-256', bytes)` rendered as hex give the identical string, so a CLI
+  report and a web report of one upload are recognisably the same measurement with no shared code.
+  The digest identifies the file **as stored** - a CRLF checkout of one logical CSV digests
+  differently from an LF one.
+- **`dataset_hash_a` / `dataset_hash_b`** - `compare` replaces `dataset_hash` with these two,
+  matching the `a` / `b` naming the compare result already uses in section 8.
+- **`reference_hash`** - present only when a section 9 baseline was supplied.
+- **`<field>_note`** - present only when the matching digest is `null`, saying why the bytes were
+  not available (stdin, an in-memory frame). An absent digest must not look like a present one, and
+  must say why it is absent.
+- **`params`** - the knobs of section 7 **as resolved**, defaults included, since a defaulted
+  threshold is as load-bearing as a typed one. The parsed `reference` table is not echoed here; it
+  is identified by `reference_hash` instead.
+- **`overrides`** - the section 1 `{column: kind}` map. It changes which columns are scored at all,
+  and a forced column is exempt from the `MAX_DIMENSION_GROUPS` drop, so it can change how many
+  dimensions exist.
+
+Every field is a function of the inputs, so `--json` output stays byte-for-byte reproducible across
+runs. `--no-provenance` restores the previous shape exactly.

--- a/faircode/cli.py
+++ b/faircode/cli.py
@@ -31,7 +31,12 @@ from . import __version__
 from .compare import compare
 from .detect import VALID_KINDS
 from .loaders_extra import get_xlsx_sheet_info, read_table
-from .profiler import parse_reference, profile
+# _resolve_opts gives the thresholds that were actually in force, defaults
+# included, which is what the provenance block has to record. Reaching for the
+# private helper follows the existing precedent in compare.py (`from .profiler
+# import _r`) and keeps profiler.py - a parity-sensitive file - untouched.
+from .profiler import _resolve_opts, parse_reference, profile
+from .provenance import build as build_provenance
 from .proxy import proxy_hints
 from .report import compare_to_terminal, to_html, compare_to_html, to_json, to_terminal
 
@@ -119,6 +124,9 @@ def main(argv: list[str] | None = None) -> int:
                    help="missing-data flag threshold (default 0.05)")
     p.add_argument("--min-group-size", type=int, metavar="N",
                    help="warn when a subgroup has fewer than N rows (default: profiler.MIN_GROUP_SIZE)")
+    p.add_argument("--no-provenance", action="store_true",
+                   help="omit the provenance block from --json output "
+                        "(restores the pre-2.1 export shape exactly)")
 
     c = sub.add_parser("compare",
                        help="compare two datasets for representation drift")
@@ -148,6 +156,9 @@ def main(argv: list[str] | None = None) -> int:
                    help="warn when a subgroup has fewer than N rows (default: profiler.MIN_GROUP_SIZE)")
     c.add_argument("--fail-on-drift", action="store_true",
                    help="exit 1 when any dimension shows drift or the overall score drops")
+    c.add_argument("--no-provenance", action="store_true",
+                   help="omit the provenance block from --json output "
+                        "(restores the pre-2.1 export shape exactly)")
 
     b = sub.add_parser("benchmark",
                        help="run the cross-domain fairness benchmark harness over every audit.yaml")
@@ -225,7 +236,13 @@ def main(argv: list[str] | None = None) -> int:
             print(f"HTML report written to {args.html}", file=sys.stderr)
 
         if args.json:
-            print(to_json(result))
+            provenance = None
+            if not args.no_provenance:
+                digests = [("dataset_hash", args.csv)]
+                if args.reference:
+                    digests.append(("reference_hash", args.reference))
+                provenance = build_provenance(digests, _resolve_opts(opts), overrides)
+            print(to_json(result, provenance=provenance))
         else:
             print(to_terminal(result))
         if args.fail_under is not None and result["overall_score"] < args.fail_under:
@@ -284,7 +301,12 @@ def main(argv: list[str] | None = None) -> int:
                 return 2
             print(f"HTML report written to {args.html}", file=sys.stderr)
         if args.json:
-            print(to_json(result))
+            provenance = None
+            if not args.no_provenance:
+                provenance = build_provenance(
+                    [("dataset_hash_a", args.csv_a), ("dataset_hash_b", args.csv_b)],
+                    _resolve_opts(opts), overrides)
+            print(to_json(result, provenance=provenance))
         else:
             print(compare_to_terminal(result))
         if args.fail_on_drift and result["flags"]:

--- a/faircode/provenance.py
+++ b/faircode/provenance.py
@@ -1,0 +1,93 @@
+"""Provenance metadata for exported profiler results (SPEC section 10).
+
+`profile()` answers "what does this dataset look like". An exported result has
+to survive a second question: "what produced these numbers". The same CSV
+scores differently under a different `--map`, a different `--min-share`, or a
+different reference baseline, and none of that was visible in the export.
+
+The block is attached at the export boundary rather than inside the engines,
+so the result shape in SPEC section 6 is unchanged and tests/test_js_parity.py
+- which compares the two engine dicts with `==` - needs no edit.
+
+Design notes worth keeping:
+
+* The digest is taken over the **raw file bytes**, not the parsed frame.
+  `hashlib.sha256().hexdigest()` and `crypto.subtle.digest('SHA-256', bytes)`
+  rendered as lowercase hex produce the identical string, so the CLI and the
+  browser agree without sharing code. A canonicalised hash of a parsed frame
+  never could.
+* When the bytes are not available (stdin, an in-memory frame), the digest is
+  `null` with a sibling `_note` saying why. A missing digest must not resemble
+  a present one, and must never quietly resemble a match.
+* Every field is a function of the inputs, so `--json` stays byte-for-byte
+  reproducible across runs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from . import __version__
+
+ENGINE = "python"
+
+_CHUNK = 1024 * 1024
+
+# Knobs whose value is a parsed data structure rather than a setting. The
+# reference table gets its own digest field, so echoing the whole parsed thing
+# into `params` would be noise.
+_OPAQUE_PARAMS = ("reference",)
+
+
+def file_digest(path):
+    """Return ("sha256:<hex>", None) for a readable file, or (None, reason).
+
+    Streamed in 1 MiB chunks so a multi-gigabyte CSV is not held in memory
+    twice. `hashlib` is stdlib, so this adds no dependency.
+    """
+    if path in (None, "", "-"):
+        return None, "read from stdin; raw bytes were not retained"
+    try:
+        digest = hashlib.sha256()
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(_CHUNK), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        return None, f"could not read {path} for hashing: {exc}"
+    return "sha256:" + digest.hexdigest(), None
+
+
+def _add_digest(block: dict, field: str, path) -> None:
+    """Set `field` on `block` to the digest of `path`, or to None plus a note."""
+    sha, note = file_digest(path)
+    block[field] = sha
+    if note is not None:
+        block[field + "_note"] = note
+
+
+def public_params(resolved: dict) -> dict:
+    """The resolved knobs, as actually applied, minus parsed data structures.
+
+    Resolved rather than "the flags the user typed": a reader needs the
+    thresholds that were in force, the defaulted ones included, or the numbers
+    still cannot be reproduced.
+    """
+    return {k: v for k, v in sorted(resolved.items()) if k not in _OPAQUE_PARAMS}
+
+
+def build(digests=(), params=None, overrides=None) -> dict:
+    """Assemble the provenance block attached to an exported result.
+
+    `digests` is a sequence of (field_name, path) pairs, emitted in the order
+    given and immediately after the version fields, so the thing that
+    identifies the run reads first.
+    """
+    block = {
+        "faircode_version": __version__,
+        "engine": ENGINE,
+    }
+    for field, path in digests:
+        _add_digest(block, field, path)
+    block["params"] = public_params(params or {})
+    block["overrides"] = dict(overrides or {})
+    return block

--- a/faircode/report.py
+++ b/faircode/report.py
@@ -14,8 +14,23 @@ WIDTH = 62
 DISPLAY_GROUPS = 12  # cap rows shown per dimension; full data stays in the result
 
 
-def to_json(result: dict, indent: int = 2) -> str:
-    return json.dumps(result, indent=indent)
+def to_json(result: dict, indent: int = 2, provenance: dict | None = None) -> str:
+    """Serialise a profile or compare result.
+
+    `provenance`, when supplied, is attached as a top-level "provenance" key
+    (SPEC section 10) so an exported report says which file, which faircode
+    version, and which resolved thresholds produced it. It is attached here
+    rather than inside profile() on purpose: the Python engine and the JS port
+    are compared with `==` in tests/test_js_parity.py, so a local file name
+    cannot live in the engine result. The web export mirrors the same field
+    names at the same boundary.
+
+    The result dict is not mutated - callers still print the terminal or HTML
+    rendering from the same object afterwards.
+    """
+    if provenance is None:
+        return json.dumps(result, indent=indent)
+    return json.dumps(dict(result, provenance=provenance), indent=indent)
 
 
 def _bar(share: float, width: int = 24) -> str:

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,179 @@
+"""Tests for the export provenance block (SPEC section 10)."""
+
+import hashlib
+import json
+
+import pytest
+
+from faircode import __version__
+from faircode.cli import main
+from faircode.provenance import build, file_digest, public_params
+from faircode.report import to_json
+
+ROWS = "gender,region,age\nmale,north,34\nfemale,south,51\nfemale,north,22\n"
+
+
+def sha_of(path) -> str:
+    """Expected digest, read back off disk.
+
+    Deliberately not sha256(ROWS.encode()): a text-mode write translates "\\n"
+    to "\\r\\n" on Windows, so the bytes on disk are not the bytes of the
+    literal. The digest identifies the file as stored, which is the property
+    the block claims - and the reason a CRLF checkout of one logical CSV
+    digests differently from an LF one.
+    """
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+@pytest.fixture
+def dataset(tmp_path):
+    path = tmp_path / "people.csv"
+    path.write_text(ROWS, encoding="utf-8")
+    return path
+
+
+# -- the digest itself -------------------------------------------------------
+
+def test_digest_is_over_raw_file_bytes(dataset):
+    """The browser hashes the uploaded bytes; the CLI hashes the same thing, or
+    a web report and a CLI report of one file can never be recognised as the
+    same measurement. Lowercase hex is what both crypto.subtle.digest and
+    hashlib.hexdigest render, so the two sides need no shared code."""
+    sha, note = file_digest(str(dataset))
+    assert sha == sha_of(dataset)
+    assert note is None
+
+
+def test_digest_changes_with_one_byte(dataset, tmp_path):
+    other = tmp_path / "people2.csv"
+    other.write_text(ROWS.replace("north", "NORTH", 1), encoding="utf-8")
+    assert file_digest(str(dataset))[0] != file_digest(str(other))[0]
+
+
+def test_missing_digest_is_null_with_a_reason_not_a_lookalike():
+    """An unavailable digest must not resemble a present one, and must say why."""
+    block = build([("dataset_hash", "-")])
+    assert block["dataset_hash"] is None
+    assert "stdin" in block["dataset_hash_note"]
+
+    unreadable = build([("dataset_hash", "no/such/file.csv")])
+    assert unreadable["dataset_hash"] is None
+    assert "no/such/file.csv" in unreadable["dataset_hash_note"]
+
+
+def test_note_is_absent_when_the_digest_is_present(dataset):
+    assert "dataset_hash_note" not in build([("dataset_hash", str(dataset))])
+
+
+def test_digest_reads_before_the_knobs(dataset):
+    """The thing that identifies the run should be the first thing read."""
+    keys = list(build([("dataset_hash", str(dataset))], {"min_share": 0.05}, {}))
+    assert keys.index("dataset_hash") < keys.index("params")
+
+
+# -- the block ---------------------------------------------------------------
+
+def test_params_are_the_resolved_ones_not_the_flags_typed():
+    resolved = {"min_share": 0.2, "missing_flag": 0.05, "reference": {"sex": {"m": 0.5}}}
+    params = public_params(resolved)
+    assert params["min_share"] == 0.2
+    assert params["missing_flag"] == 0.05
+    # the parsed reference table gets its own digest field, not an echo here
+    assert "reference" not in params
+
+
+def test_block_is_a_pure_function_of_its_inputs():
+    """Nothing wall-clock is recorded, so --json output stays byte-for-byte
+    reproducible across runs - which matters in a repo that pins numbers."""
+    assert build([], {"min_share": 0.05}, {"a": "sex"}) == \
+           build([], {"min_share": 0.05}, {"a": "sex"})
+
+
+def test_to_json_attaches_without_mutating_or_overwriting():
+    result = {"n_rows": 3, "flags": []}
+    payload = json.loads(to_json(result, provenance=build()))
+    assert payload["n_rows"] == 3
+    assert payload["flags"] == []
+    assert payload["provenance"]["faircode_version"] == __version__
+    assert "provenance" not in result  # the caller still renders terminal/HTML
+
+
+def test_to_json_unchanged_when_no_provenance_passed():
+    result = {"n_rows": 3}
+    assert json.loads(to_json(result)) == result
+
+
+# -- end to end through the CLI ---------------------------------------------
+
+def test_profile_json_carries_dataset_identity(dataset, capsys):
+    assert main(["profile", str(dataset), "--json"]) == 0
+    prov = json.loads(capsys.readouterr().out)["provenance"]
+    assert prov["faircode_version"] == __version__
+    assert prov["engine"] == "python"
+    assert prov["dataset_hash"] == sha_of(dataset)
+
+
+def test_engine_result_keys_are_untouched(dataset, capsys):
+    """Additive: the block is a new sibling key, nothing existing moves."""
+    assert main(["profile", str(dataset), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == {"n_rows", "n_cols", "overall_score", "grade",
+                            "dimensions", "intersections", "flags", "provenance"}
+
+
+def test_overrides_and_thresholds_are_recorded(dataset, capsys):
+    """A --map or a moved threshold changes the numbers. Before this block the
+    export gave a reader no way to see that it had happened."""
+    assert main(["profile", str(dataset), "--json",
+                 "--map", "region=geography", "--min-share", "0.4"]) == 0
+    prov = json.loads(capsys.readouterr().out)["provenance"]
+    assert prov["overrides"] == {"region": "geography"}
+    assert prov["params"]["min_share"] == 0.4
+    # defaulted knobs are recorded too, or the run still cannot be reproduced
+    assert prov["params"]["missing_flag"] == 0.05
+
+
+def test_reference_baseline_gets_its_own_digest(dataset, tmp_path, capsys):
+    baseline = tmp_path / "census.csv"
+    baseline.write_text("column,group,share\ngender,male,0.49\ngender,female,0.51\n",
+                        encoding="utf-8")
+    assert main(["profile", str(dataset), "--json", "--reference", str(baseline)]) == 0
+    prov = json.loads(capsys.readouterr().out)["provenance"]
+    assert prov["dataset_hash"] == sha_of(dataset)
+    assert prov["reference_hash"] == sha_of(baseline)
+
+
+def test_reference_hash_absent_when_no_baseline_given(dataset, capsys):
+    assert main(["profile", str(dataset), "--json"]) == 0
+    assert "reference_hash" not in json.loads(capsys.readouterr().out)["provenance"]
+
+
+def test_compare_json_records_both_sides(dataset, tmp_path, capsys):
+    other = tmp_path / "later.csv"
+    other.write_text(ROWS + "male,south,60\n", encoding="utf-8")
+    assert main(["compare", str(dataset), str(other), "--json"]) == 0
+    prov = json.loads(capsys.readouterr().out)["provenance"]
+    assert prov["dataset_hash_a"] == sha_of(dataset)
+    assert prov["dataset_hash_b"] == sha_of(other)
+    assert prov["dataset_hash_a"] != prov["dataset_hash_b"]
+
+
+def test_stdin_profile_still_exports_a_block(dataset, capsys, monkeypatch):
+    """Reading from stdin must not drop the version and params too."""
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(ROWS))
+    assert main(["profile", "-", "--json"]) == 0
+    prov = json.loads(capsys.readouterr().out)["provenance"]
+    assert prov["dataset_hash"] is None
+    assert "stdin" in prov["dataset_hash_note"]
+    assert prov["faircode_version"] == __version__
+    assert prov["params"]["min_share"] == 0.05
+
+
+def test_no_provenance_flag_restores_the_old_shape(dataset, capsys):
+    assert main(["profile", str(dataset), "--json", "--no-provenance"]) == 0
+    assert "provenance" not in json.loads(capsys.readouterr().out)
+
+
+def test_terminal_output_is_untouched(dataset, capsys):
+    assert main(["profile", str(dataset)]) == 0
+    assert "provenance" not in capsys.readouterr().out.lower()


### PR DESCRIPTION
Relates to #327.

`to_json()` gains an optional `provenance` block, additive to the existing shape. `--no-provenance` restores the pre-2.1 export exactly.

```json
"provenance": {
  "faircode_version": "2.0.0",
  "engine": "python",
  "dataset_hash": "sha256:827209b9…",
  "params": { "cross": null, "imbalance_flag": 3.0, "intersection_floor": 0.01, "min_group_size": 100, "min_share": 0.05, "missing_flag": 0.05, "reference_flag": 0.05 },
  "overrides": {}
}
```

`compare` gets `dataset_hash_a` / `dataset_hash_b`, following the a/b naming already in SPEC §8, and `--reference` becomes `reference_hash`.

The block attaches at the export rather than to the `profile()` result, so `test_js_parity.py` needs no change and the two engines still compare equal. `engine` is in there so #329 can be a straight port with `"js"` in that slot.

**The digest depends on line endings.** A CRLF checkout and an LF checkout of the same logical CSV hash differently. I hashed the bytes on disk rather than a normalised form, because normalising picks a winner silently. SPEC §10 says which one you get and why, so nobody has to discover it from a mismatch.

**No timestamp, on purpose.** In my own work I have a signed record whose `issued_at` sits outside the signature, and the verifier has to emit `issued_at_signed:false` every time so that nobody reads it as evidence. An unsigned timestamp inside a JSON blob is decoration rather than provenance, so I would rather not add one here than add one that needs a footnote.

Tests: 18 new in `tests/test_provenance.py`. Full suite 242 passed / 2 skipped on a fresh clone, `ruff` clean, and `scripts/check_em_dash.py` exits 0.
