### PR TITLE
fix: use bundled font for terminal renderer

### DIFF
--- a/scripts/render_terminal_png.py
+++ b/scripts/render_terminal_png.py
@@ -13,7 +13,8 @@ from pathlib import Path
 
 from PIL import Image, ImageDraw, ImageFont
 
-FONT_PATH = "/System/Library/Fonts/Menlo.ttc"
+ROOT = Path(__file__).resolve().parent.parent
+FONT_PATH = ROOT / "assets" / "fonts" / "IBMPlexMono-Regular.ttf"
 FONT_SIZE = 15
 LINE_HEIGHT = 21
 PAD_X = 18
@@ -25,7 +26,7 @@ MAX_WIDTH_CHARS = 92
 
 def render(text: str, out_path):
     lines = text.rstrip("\n").split("\n")
-    font = ImageFont.truetype(FONT_PATH, FONT_SIZE)
+    font = ImageFont.truetype(str(FONT_PATH), FONT_SIZE)
 
     # Measure with a scratch image, since char width needs a real font metric.
     scratch = Image.new("RGB", (10, 10))


### PR DESCRIPTION
## Summary

Fixes the terminal PNG renderer to use the repository's bundled IBM Plex Mono font instead of the macOS-only Menlo font.

This makes `scripts/render_terminal_png.py` work on non-macOS systems as well.

## Type

- [ ] Audit
- [ ] Explainer
- [x] Bug fix
- [ ] Other

## Testing

- `python3 scripts/render_terminal_png.py /tmp/fair-code-test.txt /tmp/fair-code-test.png`
- `file /tmp/fair-code-test.png`
- `make check`
- `git diff --check`

All checks passed: **212 passed, 6 skipped**.
