### PR TITLE
docs: fix stale explainer.html README comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Fair-Code/
 │   ├── og/                              #   dark-theme OG share images, per explainer
 │   ├── og-light/                        #   light-theme counterparts
 │   └── profiler-engine.js, profiler-ui.js, profiler-compare.js, profiler.css   # client-side profiler
-├── explainer.html                       # explainer-page template, rendered per slug by build_explainers.py
+├── explainer.html                       # static ?slug= redirect shim -> explainers/<slug>.html (see DEAD-FILE-AUDIT.md)
 ├── index.html                           # live at thefaircode.xyz
 ├── profiler.html                        # Open Dataset Profiler - client-side web tool
 ├── requirements.txt                     # loose version ranges - for everyday development


### PR DESCRIPTION
Fix the stale `explainer.html` repository-tree comment in `README.md`.

The previous comment incorrectly described `explainer.html` as an explainer-page template rendered by `scripts/build_explainers.py`. In reality, it is a static `?slug=` redirect shim that points to `explainers/<slug>.html`.

This updates the README comment to accurately reflect the current implementation and references `DEAD-FILE-AUDIT.md` for additional context.

Closes #326

Testing

Documentation-only change. No code changes or tests are required.
