### PR TITLE
Fix proxy hints with flag activation

### DIFF
--- a/faircode/cli.py
+++ b/faircode/cli.py
@@ -253,7 +253,7 @@ def main(argv: list[str] | None = None) -> int:
         _check_map_columns(overrides, df.columns)
         result = profile(df, overrides, opts)
 
-        if args.proxy_hints:
+        if args.proxy_hints or args.proxy_hints_with:
             held_out = _build_held_out(args.proxy_hints_with, df)
             try:
                 result["proxy_hints"] = proxy_hints(df, result["dimensions"], held_out=held_out)


### PR DESCRIPTION
Summary

Fixes a bug where --proxy-hints-with silently had no effect unless --proxy-hints was also provided.

The proxy-hints path now activates when either --proxy-hints or --proxy-hints-with is supplied. This makes --proxy-hints-with usable on its own instead of requiring a redundant --proxy-hints flag.

Although the usual approach would be to flag this as an issue in the CLI, I think requiring users to type --proxy-hints --proxy-hints-with when --proxy-hints-with already expresses the intended behavior would be redundant.

Changes
Update the proxy-hints activation condition to accept either flag.
Preserve the existing behavior when --proxy-hints is used alone.
Verification
Existing test suite passes.
--proxy-hints-with now activates the proxy-hints functionality without requiring --proxy-hints.

Closes #347