### PR TITLE
faircode profile: error when --proxy-hints-with is passed without --proxy-hints

### DIFF
--- a/faircode/cli.py
+++ b/faircode/cli.py
@@ -212,6 +212,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "profile":
+        if args.proxy_hints_with and not args.proxy_hints:
+            print("error: --proxy-hints-with needs --proxy-hints", file=sys.stderr)
+            return 2
+
         df = _read_or_exit(args.csv)
 
         sheet_info = get_xlsx_sheet_info(args.csv)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -393,6 +393,18 @@ def test_proxy_hints_with_row_count_mismatch_returns_2_with_clean_error(tmp_path
     assert "rows must align 1:1" in captured.err
 
 
+def test_proxy_hints_with_without_proxy_hints_returns_2_with_clean_error(tmp_path, capsys):
+    path = tmp_path / "a.csv"
+    path.write_text("sex\nM\nF\n", encoding="utf-8")
+
+    exit_code = main(["profile", str(path),
+                      "--proxy-hints-with", "/nonexistent/file.csv=race"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "--proxy-hints-with needs --proxy-hints" in captured.err
+
+
 requires_scipy = pytest.mark.skipif(
     importlib.util.find_spec("scipy") is None,
     reason="optional 'proxy' extra not installed",


### PR DESCRIPTION
--proxy-hints-with was silently ignored unless --proxy-hints was also
set, since _build_held_out was only ever called inside the
`if args.proxy_hints:` branch. A typo'd invocation (forgetting
--proxy-hints) exited 0 with a normal profile report instead of
surfacing the mistake.

Fixes #347
