### PR TITLE
Update llms.txt

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -24,6 +24,12 @@ Full text of every explainer in one file (for AI answer engines): https://www.th
 
 ## Explainers
 
+- [What Is Accuracy Equality?](https://www.thefaircode.xyz/explainers/accuracy-equality.html)
+- [What Is a Bootstrap Confidence Interval (and a Permutation Test)?](https://www.thefaircode.xyz/explainers/bootstrap-confidence-intervals.html)
+- [What Are Pre-, In-, and Post-Processing Fairness Mitigations?](https://www.thefaircode.xyz/explainers/mitigation-strategies.html)
+- [Why Fairness Through Unawareness Fails](https://www.thefaircode.xyz/explainers/fairness-through-unawareness.html)
+- [What Is LIME?](https://www.thefaircode.xyz/explainers/lime.html)
+- [What Is a Counterfactual Explanation? (And How It Differs From Counterfactual Fairness)](https://www.thefaircode.xyz/explainers/counterfactual-explanation.html)
 - [What Is Intersectional Bias?](https://www.thefaircode.xyz/explainers/intersectional-bias.html)
 - [What Is Equal Opportunity (and How It Differs From Equalized Odds)?](https://www.thefaircode.xyz/explainers/equal-opportunity.html)
 - [What Is a Precision-Recall Curve?](https://www.thefaircode.xyz/explainers/precision-recall-curve.html)


### PR DESCRIPTION
Add the 6 most recently added explainers to llms.txt's index

llms.txt is maintained separately from llms-full.txt and had drifted:
accuracy-equality, bootstrap-confidence-intervals, mitigation-strategies,
fairness-through-unawareness, lime, and counterfactual-explanation were
all published but invisible to anything that only reads the short index.
Added at the top, matching the list's newest-first ordering.

Fixes #342 