### PR TITLE
Update scanned file extensions in check_em_dash.py

### DIFF
--- a/scripts/check_em_dash.py
+++ b/scripts/check_em_dash.py
@@ -19,8 +19,8 @@ from pathlib import Path
 EM_DASH = "\u2014"  # em dash, the forbidden character
 EN_DASH = "\u2013"  # en dash, allowed for numeric ranges
 
-# Only contributor-facing source/prose is scanned. Data (.csv) and dependency
-# pins (.txt) are deliberately out of scope.
+# Tracked text files with these extensions are scanned for em dashes. Data (.csv)
+# and dependency pins (.txt) are deliberately out of scope.
 SCAN_EXT = {".md", ".py", ".js", ".html", ".css", ".yml", ".yaml"}
 
 # Opt-out path list (the escape hatch): files that legitimately contain an em

--- a/scripts/check_em_dash.py
+++ b/scripts/check_em_dash.py
@@ -19,9 +19,9 @@ from pathlib import Path
 EM_DASH = "\u2014"  # em dash, the forbidden character
 EN_DASH = "\u2013"  # en dash, allowed for numeric ranges
 
-# Only contributor-facing source/prose is scanned. Data (.csv), config (.yml),
-# and dependency pins (.txt) are deliberately out of scope.
-SCAN_EXT = {".md", ".py", ".js", ".html", ".css"}
+# Only contributor-facing source/prose is scanned. Data (.csv) and dependency
+# pins (.txt) are deliberately out of scope.
+SCAN_EXT = {".md", ".py", ".js", ".html", ".css", ".yml", ".yaml"}
 
 # Opt-out path list (the escape hatch): files that legitimately contain an em
 # dash, or that must not be edited. Keep this list short and justified.
@@ -30,6 +30,9 @@ ALLOWLIST = {
     "faircode/significance.py",
     # Documents the rule itself and shows em dashes as the anti-pattern to avoid.
     "CONTRIBUTING.md",
+    # Same reason: demonstrates the banned character inside a checkbox label.
+    ".github/ISSUE_TEMPLATE/new_audit.yml",
+    ".github/ISSUE_TEMPLATE/new_explainer.yml",
 }
 ALLOW_PREFIXES = ("paper/results-frozen/",)  # frozen evidence, never modified
 


### PR DESCRIPTION
Scan .yml/.yaml files for em dashes, allowlist the two that demonstrate one

The em-dash-free convention is meant to apply repo-wide, but SCAN_EXT
excluded YAML entirely, leaving two real em dashes in
new_audit.yml/new_explainer.yml unflagged by CI. Added .yml/.yaml to
SCAN_EXT and allowlisted those two files, which intentionally show the
banned character inside a checkbox label - the same reason
CONTRIBUTING.md is already allowlisted.

Fixes #343
