### PR TITLE
fix(mcp): report missing results mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ first shipped.
 - **`get_explainer` had a path-traversal vulnerability via `slug`** (closes #387) - `slug="../README"` returned this repo's `README.md` content, a file entirely outside `explainers/`, since `slug` was used to build a filesystem path with zero validation. Now validated against the exact pattern every real slug matches before the path is ever built.
 - **`profile_dataset`'s `cross` validation didn't reject the same column twice, unlike the CLI** (closes #389) - `cross=["sex","sex"]` silently produced a degenerate diagonal-only intersection table instead of erroring like `faircode profile --cross sex,sex` already does.
 - **`get_benchmark_results` crashed uncaught or leaked raw pandas errors on a non-scalar filter value** (closes #390) - a dict value raised an uncaught `NotImplementedError` (not in the tool wrapper's except tuple); a list value raised `ValueError` with pandas' own internal wording. Each filter is now validated as a plain scalar first.
+- **`get_benchmark_results` blamed the wrong file when its package mirror was missing** (closes #396) - the error now names the actual missing `faircode/_results_frozen/` path and points to `scripts.freeze_paper_results.mirror_for_mcp()`, avoiding advice that could trigger an unnecessary, citation-affecting re-freeze.
 - **README.md's MCP section still listed only the original 3 tools** (closes #391) - `SPEC.md` section 11 was already correctly updated for all six.
 
 ## [2.1.1] - 02 Sep 2026

--- a/faircode/mcp_server.py
+++ b/faircode/mcp_server.py
@@ -11,8 +11,8 @@ different way to call the same profile()/compare()/proxy_hints() functions
 cli.py already wraps. See faircode/SPEC.md section 11 for the tool contract.
 
 Phase 2 (list_explainers, get_explainer, get_benchmark_results) adds
-read-only lookups against this repo's own explainers/ and
-paper/results-frozen/ - the plan mentioned in CHANGELOG.md's Phase 1 note.
+read-only lookups against package-internal mirrors of this repo's explainers/
+and frozen benchmark results - the plan mentioned in CHANGELOG.md's Phase 1 note.
 
 Needs the optional 'mcp' extra (`pip install faircode[mcp]`).
 
@@ -299,8 +299,8 @@ def _get_benchmark_results_impl(kind="fairness", audit=None, model=None, strateg
         raise ValueError(f"kind must be one of {sorted(RESULTS_FROZEN_FILES)}, got {kind!r}")
     if not path.is_file():
         raise FileNotFoundError(
-            f"{path.name} not found - paper/results-frozen/ may not have been frozen yet "
-            "(see scripts/freeze_paper_results.py)")
+            f"{path} not found - restore the package mirror from paper/results-frozen/ "
+            "with `scripts.freeze_paper_results.mirror_for_mcp()`")
     df = pd.read_csv(path)
     for column, value in (("audit", audit), ("model", model), ("strategy", strategy),
                           ("metric", metric), ("protected_attribute", protected_attribute)):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16,6 +16,7 @@ pytest.importorskip("mcp", reason="MCP tools need the optional mcp extra")
 
 from faircode.mcp_server import (  # noqa: E402
     _compare_datasets_impl,
+    RESULTS_FROZEN_FILES,
     _get_benchmark_results_impl,
     _get_explainer_impl,
     _list_explainers_impl,
@@ -450,6 +451,20 @@ def test_get_benchmark_results_no_match_returns_empty_not_an_error():
 def test_get_benchmark_results_invalid_kind_raises():
     with pytest.raises(ValueError, match="kind must be one of"):
         _get_benchmark_results_impl(kind="not_a_real_kind")
+
+
+def test_get_benchmark_results_missing_mirror_names_path_and_safe_recovery(
+        tmp_path, monkeypatch):
+    missing = tmp_path / "faircode" / "_results_frozen" / "results_fairness.csv"
+    monkeypatch.setitem(RESULTS_FROZEN_FILES, "fairness", missing)
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        _get_benchmark_results_impl()
+
+    message = str(exc_info.value)
+    assert str(missing) in message
+    assert "scripts.freeze_paper_results.mirror_for_mcp()" in message
+    assert "may not have been frozen" not in message
 
 
 @pytest.mark.parametrize("bad_value", [{"x": 1}, ["a", "b"], (1, 2)])


### PR DESCRIPTION
## Problem

`get_benchmark_results` reads the package-internal `faircode/_results_frozen/` mirror, but its missing-file error blamed `paper/results-frozen/` and suggested re-running the freeze script. Following that advice could perform an unnecessary citation-affecting re-freeze.

## Change

- report the exact missing mirror path
- direct recovery to the non-destructive `scripts.freeze_paper_results.mirror_for_mcp()` helper
- add a regression test covering the path, recovery guidance, and removal of the misleading freeze claim
- correct the MCP module description and changelog entry

## Verification

- `make check` in a clean virtualenv with the declared `mcp>=2.0` dependency: **278 passed, 8 skipped**
- `make lint`: em-dash check, 1,260 internal links, and Ruff all passed

Closes #396