### PR TITLE
Fix README.md's faircode/ repo-tree omits mcp_server.py, _explainers/, and _results_frozen/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+S<div align="center">
 
 # Fair Code - Algorithmic Bias Detection & Mitigation
 
@@ -186,7 +186,10 @@ Fair-Code/
 │   ├── metrics.py                       #   6 fairness metrics + accuracy/AUC/F1
 │   ├── benchmark.py                     #   orchestrator - manifests → strategies → metrics → tables
 │   ├── figures.py                       #   renders results_fairness.csv → figures/*.png (300 dpi)
-│   └── cli.py                           #   `faircode profile` / `compare` / `benchmark` entry point
+│   ├── cli.py                           #   `faircode profile` / `compare` / `benchmark` entry point
+|   ├── _explainers/                     # generated mirror of explainers/*.md
+|   ├── _results_frozen/                 # generated mirror of paper/results-frozen/*.csv
+|   └── mcp_server.py                    # 6 MCP tools exposing Fair-Code engine over MCP
 ├── tests/
 │   ├── fixtures/                        #   sample datasets for loader/edge-case tests
 │   ├── test_benchmark.py                # end-to-end benchmark harness tests


### PR DESCRIPTION
## Summary
Adds add mcp_server.py, _explainers/ (with a one-line note it's a generated mirror of explainers/.md), and _results_frozen/ (generated mirror of paper/results-frozen/.csv) to the tree.
Closes yakew7#409
