### PR TITLE
fix: exclude generated explainers mirror from em-dash scan

### DIFF
--- a/scripts/check_em_dash.py
+++ b/scripts/check_em_dash.py
@@ -34,7 +34,10 @@ ALLOWLIST = {
     ".github/ISSUE_TEMPLATE/new_audit.yml",
     ".github/ISSUE_TEMPLATE/new_explainer.yml",
 }
-ALLOW_PREFIXES = ("paper/results-frozen/",)  # frozen evidence, never modified
+ALLOW_PREFIXES = (
+    "paper/results-frozen/",  # frozen evidence, never modified
+    "faircode/_explainers/",  # generated mirror of explainers/*.md, checking the source already covers it
+)
 
 
 def _tracked_files():


### PR DESCRIPTION
Fixes #393

`faircode/_explainers/*.md` is a generated, package-internal mirror of `explainers/*.md` (byte-identical copies). `check_em_dash.py`'s `ALLOW_PREFIXES` only excluded `paper/results-frozen/`, so an em dash in `explainers/foo.md` gets reported twice under two different-looking paths for the same root cause.

Added `faircode/_explainers/` to `ALLOW_PREFIXES`, same pattern as the existing `paper/results-frozen/` exclusion.

## Test plan
- [x] `python3 scripts/check_em_dash.py` passes locally