### PR TITLE
fix: raise ValueError for unrecognized strategy names in strategy_features()

### DIFF
--- a/faircode/strategies.py
+++ b/faircode/strategies.py
@@ -99,7 +99,7 @@ def strategy_features(strategy: str, core: list, proxies: list, protected: list)
         return list(dict.fromkeys(core + proxies + protected))
     if strategy == "unawareness":
         return list(dict.fromkeys(core + proxies))
-if strategy in ("unawareness_proxy_removal", "in_processing", "post_processing"):
+    if strategy in ("unawareness_proxy_removal", "in_processing", "post_processing"):
         return list(dict.fromkeys(core))
     raise ValueError(f"unknown strategy: {strategy!r}")
 

--- a/faircode/strategies.py
+++ b/faircode/strategies.py
@@ -99,7 +99,9 @@ def strategy_features(strategy: str, core: list, proxies: list, protected: list)
         return list(dict.fromkeys(core + proxies + protected))
     if strategy == "unawareness":
         return list(dict.fromkeys(core + proxies))
-    return list(core)  # unawareness_proxy_removal, in_processing, post_processing
+    if strategy in ("unawareness_proxy_removal", "in_processing", "post_processing"):
+        return list(core)
+    raise ValueError(f"unknown strategy: {strategy!r}")
 
 
 def fit_in_processing(base_model, X_train, y_train, sensitive_train):

--- a/faircode/strategies.py
+++ b/faircode/strategies.py
@@ -99,8 +99,8 @@ def strategy_features(strategy: str, core: list, proxies: list, protected: list)
         return list(dict.fromkeys(core + proxies + protected))
     if strategy == "unawareness":
         return list(dict.fromkeys(core + proxies))
-    if strategy in ("unawareness_proxy_removal", "in_processing", "post_processing"):
-        return list(core)
+if strategy in ("unawareness_proxy_removal", "in_processing", "post_processing"):
+        return list(dict.fromkeys(core))
     raise ValueError(f"unknown strategy: {strategy!r}")
 
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -65,6 +65,16 @@ def test_strategy_features_deduplicates_overlapping_names():
     assert set(cols) == {"a", "b", "c"}
 
 
+def test_strategy_features_raises_on_unknown_strategy():
+    with pytest.raises(ValueError, match="unknown strategy: 'in_procesing'"):
+        strategy_features("in_procesing", CORE, PROXIES, PROTECTED)
+
+
+def test_strategy_features_raises_on_empty_string():
+    with pytest.raises(ValueError, match="unknown strategy: ''"):
+        strategy_features("", CORE, PROXIES, PROTECTED)
+
+
 # ── encode_features ──────────────────────────────────────────────────────────
 def test_encode_features_passes_numeric_columns_through():
     df = pd.DataFrame({"age": [20.0, 30.0, 40.0]})


### PR DESCRIPTION
Fixes #418

## What

`faircode/strategies.py::strategy_features()` silently accepted any unrecognized strategy name. The final `return list(core)` is a bare `else` in practice - meant to handle exactly `unawareness_proxy_removal`, `in_processing`, and `post_processing`, but a typo like `"in_procesing"` fell through to the same branch and returned a wrong-but-plausible column set with no error.

## Change

Replaced the bare catch-all with an explicit membership check for the three known core-only strategies, and added `raise ValueError(f"unknown strategy: {strategy!r}")` for anything else.

## Why it matters

While `faircode/benchmark.py` only iterates the fixed `STRATEGIES` tuple today, `strategy_features` is a public (no leading underscore) function that anyone can import directly from a notebook, script, or future extension. A typo'd name silently produced a plausible wrong answer instead of an error.

## Tests

Added two tests to `tests/test_strategies.py`:
- `test_strategy_features_raises_on_unknown_strategy` - a typo'd name (`"in_procesing"`) raises `ValueError`
- `test_strategy_features_raises_on_empty_string` - empty string raises `ValueError`

All 13 tests in `tests/test_strategies.py` pass; `ruff check` is clean on both touched files.