### PR TITLE
Handle singleton classes in post-processing splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to Fair Code are documented here, newest first.
 
 ## [2.2.0] - 02 Sep 2026
 
+- **`fit_post_processing()` crashed while splitting a singleton target class** (closes #446) - stratification now checks every observed class count before passing labels to scikit-learn, while retaining stratified calibration splits whenever all classes support them.
+
 Three rounds of a fresh MCP-focused audit, each finding real gaps through direct verification
 (not guessed), fixing them, and adding one Phase 2 capability - completing the "read-only lookups
 against `paper/results-frozen/` and `explainers/`" plan named as a follow-up when the MCP server

--- a/faircode/strategies.py
+++ b/faircode/strategies.py
@@ -152,7 +152,12 @@ def fit_post_processing(base_model, X_train, y_train, sensitive_train,
     calibrating against the rows the model memorized.
     """
     idx = np.arange(len(y_train))
-    stratify = y_train if len(np.unique(y_train)) > 1 else None
+    _, class_counts = np.unique(y_train, return_counts=True)
+    # StratifiedShuffleSplit requires at least two members in every observed
+    # class. Sparse audit subsets can still use the existing random split;
+    # passing their labels through would raise before either split is made.
+    can_stratify = len(class_counts) > 1 and class_counts.min() >= 2
+    stratify = y_train if can_stratify else None
     fit_idx, calib_idx = train_test_split(
         idx, test_size=calibration_size, random_state=random_state, stratify=stratify)
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -14,7 +14,8 @@ import pytest
 
 pytest.importorskip("fairlearn", reason="faircode.strategies needs the optional fairlearn extra")
 
-from faircode.strategies import STRATEGIES, encode_features, strategy_features
+import faircode.strategies as strategies
+from faircode.strategies import STRATEGIES, encode_features, fit_post_processing, strategy_features
 
 CORE = ["income", "education"]
 PROXIES = ["zip_code"]
@@ -109,3 +110,50 @@ def test_encode_features_only_touches_requested_columns():
     out = encode_features(df, ["a"])
     assert list(out.columns) == ["a"]
     assert "b" not in out.columns
+
+
+# -- fit_post_processing: calibration split ----------------------------------
+class _RecordingModel:
+    def fit(self, X, y):
+        self.fit_rows = X.index.tolist()
+
+
+class _RecordingOptimizer:
+    def __init__(self, **kwargs):
+        self.init_kwargs = kwargs
+
+    def fit(self, X, y, sensitive_features):
+        self.calibration_rows = X.index.tolist()
+
+
+@pytest.mark.parametrize(
+    ("y_train", "expected_stratify"),
+    [
+        (np.array([0] * 19 + [1]), None),
+        (np.array([0] * 18 + [1, 1]), "labels"),
+    ],
+)
+def test_post_processing_only_stratifies_when_every_class_has_two_members(
+        monkeypatch, y_train, expected_stratify):
+    captured = {}
+    real_split = strategies.train_test_split
+
+    def recording_split(*args, **kwargs):
+        captured["stratify"] = kwargs["stratify"]
+        return real_split(*args, **kwargs)
+
+    monkeypatch.setattr(strategies, "train_test_split", recording_split)
+    monkeypatch.setattr(strategies, "ThresholdOptimizer", _RecordingOptimizer)
+    X_train = pd.DataFrame({"feature": np.arange(len(y_train))})
+    sensitive_train = np.array([0, 1] * (len(y_train) // 2))
+    model = _RecordingModel()
+
+    optimizer = fit_post_processing(
+        model, X_train, y_train, sensitive_train, random_state=42)
+
+    if expected_stratify is None:
+        assert captured["stratify"] is None
+    else:
+        np.testing.assert_array_equal(captured["stratify"], y_train)
+    assert set(model.fit_rows).isdisjoint(optimizer.calibration_rows)
+    assert set(model.fit_rows) | set(optimizer.calibration_rows) == set(X_train.index)


### PR DESCRIPTION
Fixes #446.

Post-processing now checks the smallest observed target-class count before asking scikit-learn for a stratified fit/calibration split. Singleton and single-class inputs use the existing random split, while supported inputs remain stratified.

Tests cover both paths and verify that fit and calibration rows stay disjoint and complete.

Validation: `make check` (312 passed, 20 skipped).
