### PR TITLE
fix: sniff delimiters for CSV and TSV files

### DIFF
--- a/faircode/loaders.py
+++ b/faircode/loaders.py
@@ -30,14 +30,19 @@ def read_table(path: str) -> pd.DataFrame:
             ) from exc
 
     if suffix == ".tsv":
-        return pd.read_csv(path, sep="\t")
+        return _read_delimited(path, default="\t")
 
     if suffix == ".csv":
-        return pd.read_csv(path)
+        return _read_delimited(path, default=",")
 
+    return _read_delimited(path, default=",")
+
+
+def _read_delimited(path: str, *, default: str) -> pd.DataFrame:
+    """Read delimited text, using the extension's convention only as fallback."""
     with open(path, "r", encoding="utf-8", errors="replace", newline="") as fh:
         sample = fh.read(SNIFF_SAMPLE_BYTES)
-    return pd.read_csv(path, sep=_sniff_delimiter(sample))
+    return pd.read_csv(path, sep=_sniff_delimiter(sample, default=default))
 
 
 def _sniff_delimiter(sample: str, default: str = ",") -> str:

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -67,6 +67,19 @@ def test_read_table_csv(tmp_path):
     df = read_table(str(path))
     assert list(df.columns) == ["patient_id", "sex", "age"]
 
+
+@pytest.mark.parametrize(
+    ("suffix", "separator"),
+    [(".csv", ";"), (".tsv", ",")],
+)
+def test_read_table_sniffs_delimiter_despite_extension(tmp_path, suffix, separator):
+    path = tmp_path / f"data{suffix}"
+    expected = _write_csv(path, sep=separator)
+
+    actual = read_table(str(path))
+
+    pd.testing.assert_frame_equal(actual, expected)
+
 @pytest.mark.parametrize(
     "orient",
     ["records", "split"],


### PR DESCRIPTION
## Summary

Sniffs delimited file contents before parsing so mislabeled CSV and TSV files retain their columns, while keeping extension-specific fallback delimiters.

## Type

- [ ] Audit
- [ ] Explainer
- [x] Bug fix
- [ ] Other

## Linked issue

Closes #439

## Validation

- `make check` (214 passed, 34 skipped)
