### PR TITLE
fix: preserve mid-field quotes in CSV values

### DIFF
--- a/assets/profiler-engine.js
+++ b/assets/profiler-engine.js
@@ -107,7 +107,7 @@
           if (text[i + 1] === '"') { field += '"'; i++; }
           else inQuotes = false;
         } else field += c;
-      } else if (c === '"') {
+      } else if (c === '"' && field === '') {
         inQuotes = true;
       } else if (c === delimiter) {
         row.push(field); field = '';

--- a/tests/test_js_parity.py
+++ b/tests/test_js_parity.py
@@ -78,6 +78,36 @@ def test_python_js_profiler_parity(csv_name):
     assert javascript_result == python_result
 
 
+def test_python_js_profiler_parity_preserves_mid_field_quotes(tmp_path):
+    """Quotes after field content are literal in pandas and the browser parser."""
+    csv = tmp_path / "space_before_quote.csv"
+    csv.write_text(
+        'sex, race, age\n'
+        'Male, "White", 25\n'
+        'Female, "Black", 30\n'
+        'Male, "White", 45\n'
+        'Female, "Asian", 22\n',
+        encoding="utf-8",
+    )
+
+    python_result = profile(pd.read_csv(csv))
+    completed = subprocess.run(
+        ["node", "scripts/engine-js.js", "profile", str(csv)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    )
+    javascript_result = json.loads(completed.stdout)
+
+    python_result = dict(python_result)
+    javascript_result = dict(javascript_result)
+    python_result.pop("flags", None)
+    javascript_result.pop("flags", None)
+
+    assert javascript_result == python_result
+
+
 def test_python_js_profiler_parity_with_overrides_cross_and_thresholds(tmp_path):
     """Non-default options - --map/--cross/--reference/thresholds - only ever
     had cross-engine parity coverage for their default-off path (issue #376).


### PR DESCRIPTION
## Summary

Preserves quote characters that appear after existing field content in the browser CSV parser, matching pandas semantics for exports with spaces before quotes.

## Type

- [ ] Audit
- [ ] Explainer
- [x] Bug fix
- [ ] Other

## Linked issue

Closes #441

## Validation

- `make check` (213 passed, 34 skipped)
