### PR TITLE
fix: sniff delimiters across quoted newlines

### DIFF
--- a/assets/profiler-engine.js
+++ b/assets/profiler-engine.js
@@ -77,15 +77,48 @@
 
   // ── Delimiter sniffing (SPEC-adjacent; mirrors faircode/loaders.py) ─────
   // Picks whichever of , \t ; | appears the same number of times on every
-  // sampled line - so a tab-separated export saved as .csv still parses.
+  // sampled logical row - so quoted newlines do not corrupt the sample.
   var DELIMITER_CANDIDATES = [',', '\t', ';', '|'];
 
+  function logicalRowDelimiterCounts(text, delimiter) {
+    var counts = [], count = 0, inQuotes = false;
+    var atFieldStart = true, hasContent = false;
+    for (var i = 0; i < text.length && counts.length < 5; i++) {
+      var c = text[i];
+      if (inQuotes) {
+        if (c === '"') {
+          if (text[i + 1] === '"') i++;
+          else inQuotes = false;
+        }
+      } else if (c === '"' && atFieldStart) {
+        inQuotes = true;
+        hasContent = true;
+      } else if (c === delimiter) {
+        count++;
+        atFieldStart = true;
+        hasContent = true;
+      } else if (c === '\n' || c === '\r') {
+        if (c === '\r' && text[i + 1] === '\n') i++;
+        if (hasContent) counts.push(count);
+        count = 0;
+        atFieldStart = true;
+        hasContent = false;
+      } else {
+        atFieldStart = false;
+        hasContent = true;
+      }
+    }
+    if (counts.length < 5 && hasContent && !inQuotes) counts.push(count);
+    return counts;
+  }
+
   function sniffDelimiter(text) {
-    var sample = text.slice(0, 8192).split(/\r\n|\r|\n/).filter(Boolean).slice(0, 5);
-    if (!sample.length) return ',';
+    var sample = text.slice(0, 8192);
+    if (!sample) return ',';
     var best = ',', bestCount = -1;
     DELIMITER_CANDIDATES.forEach(function (d) {
-      var counts = sample.map(function (line) { return line.split(d).length - 1; });
+      var counts = logicalRowDelimiterCounts(sample, d);
+      if (!counts.length) return;
       var first = counts[0];
       if (first <= 0) return;
       var consistent = counts.every(function (c) { return c === first; });

--- a/tests/test_js_parity.py
+++ b/tests/test_js_parity.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 
 from faircode import compare, profile
+from faircode.loaders import read_table
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
@@ -93,6 +94,37 @@ def test_python_js_profiler_parity_preserves_mid_field_quotes(tmp_path):
     python_result = profile(pd.read_csv(csv))
     completed = subprocess.run(
         ["node", "scripts/engine-js.js", "profile", str(csv)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    )
+    javascript_result = json.loads(completed.stdout)
+
+    python_result = dict(python_result)
+    javascript_result = dict(javascript_result)
+    python_result.pop("flags", None)
+    javascript_result.pop("flags", None)
+
+    assert javascript_result == python_result
+
+
+def test_python_js_profiler_parity_sniffs_quoted_newlines(tmp_path):
+    """Embedded newlines do not split logical rows during delimiter sniffing."""
+    dataset = tmp_path / "sniff_quoted_newline.dat"
+    dataset.write_text(
+        'sex;race;age;notes\n'
+        'M;White;25;"single line"\n'
+        'F;Black;30;"multi\nline note"\n'
+        'M;White;45;"ok"\n'
+        'F;Asian;22;"fine"\n'
+        'M;White;50;"good"\n',
+        encoding="utf-8",
+    )
+
+    python_result = profile(read_table(str(dataset)))
+    completed = subprocess.run(
+        ["node", "scripts/engine-js.js", "profile", str(dataset)],
         capture_output=True,
         text=True,
         encoding="utf-8",


### PR DESCRIPTION
## Summary

Makes browser delimiter sampling follow logical quoted rows, so embedded newlines no longer force semicolon data into one comma-delimited column.

## Type

- [ ] Audit
- [ ] Explainer
- [x] Bug fix
- [ ] Other

## Linked issue

Closes #440

## Validation

- `make check` (216 passed, 34 skipped)
