### PR TITLE
fix: show omitted groups in HTML reports

### DIFF
--- a/assets/profiler-ui.js
+++ b/assets/profiler-ui.js
@@ -631,11 +631,14 @@
       if (d.skewness !== null) metaParts.push('skew ' + (d.skewness >= 0 ? '+' : '') + d.skewness.toFixed(2));
       var metaHtml = metaParts.length
         ? ' <span class="meta">(' + esc(metaParts.join('  ')) + ')</span>' : '';
+      var moreHtml = d.groups.length > DISPLAY_GROUPS
+        ? '<div class="dim-more">… and ' + (d.groups.length - DISPLAY_GROUPS) + ' more groups</div>'
+        : '';
 
       return '<section class="dim"><h2>' + esc(d.name) +
         ' <span class="kind">' + esc(d.kind) + '</span> ' +
         '<span class="score">' + d.dimension_score + '/100</span>' + metaHtml + '</h2>' +
-        '<table>' + rows + '</table>' + referenceHtml + '</section>';
+        '<table>' + rows + '</table>' + moreHtml + referenceHtml + '</section>';
     }).join('');
 
     var flagHtml = '';
@@ -670,6 +673,7 @@
       ' tr.under td.bar span { background:var(--accent); }\n' +
       ' tr.under td:first-child::after { content:\' (under-represented)\'; color:var(--accent); font-size:11px; }\n' +
       ' tr.small-group td:first-child::before { content:\'⚠ small group \'; color:var(--accent); }\n' +
+      ' .dim-more { font-size:12px; color:var(--muted); margin-top:8px; font-style:italic; }\n' +
       ' .reference { margin-top:10px; padding-top:10px; border-top:1px dashed var(--border); }\n' +
       ' .reference h3 { font-size:.75em; margin:0 0 6px; }\n' +
       ' .reference th { text-align:right; font-size:11px; color:var(--muted); font-weight:normal; }\n' +

--- a/faircode/SPEC.md
+++ b/faircode/SPEC.md
@@ -199,6 +199,10 @@ with `imbalance_ratio ≥ 3`, every dimension with `missing_pct ≥ 0.05`, and e
 
 ## 7. Defaults (single place to tune)
 
+Human-readable terminal, browser, and exported HTML reports show at most the first **12** groups
+per dimension. Whenever a dimension contains more groups, every report surface must state exactly
+how many groups were omitted; the structured result remains complete.
+
 The flagging thresholds are overridable per run without editing source: `profile(df, opts={...})`
 in Python, `profile(table, overrides, opts)` in JS, and `--min-share` / `--intersection-floor` /
 `--imbalance-flag` / `--missing-flag` / `--min-group-size` on the CLI. Omitted knobs fall back to the defaults below.

--- a/faircode/report.py
+++ b/faircode/report.py
@@ -246,6 +246,12 @@ def to_html(result: dict) -> str:
             f' <span class="meta">({esc("  ".join(meta_parts))})</span>'
             if meta_parts else ""
         )
+        more_html = ""
+        if len(d["groups"]) > DISPLAY_GROUPS:
+            more_html = (
+                f'<div class="dim-more">… and '
+                f'{len(d["groups"]) - DISPLAY_GROUPS} more groups</div>'
+            )
 
         dim_blocks.append(
             f'<section class="dim"><h2>{esc(d["name"])} '
@@ -255,7 +261,7 @@ def to_html(result: dict) -> str:
             f'<thead><tr><th scope="col">Group</th><th scope="col" class="num">Share</th>'
             f'<th scope="col" class="num">95% CI</th><th scope="col" class="num">Count</th>'
             f'<th scope="col" class="bar"></th></tr></thead>'
-            f'<tbody>{"".join(rows)}</tbody></table>{reference_html}</section>'
+            f'<tbody>{"".join(rows)}</tbody></table>{more_html}{reference_html}</section>'
         )
 
     flag_html = ""

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -91,6 +91,26 @@ def test_to_html_renders_key_figures(mock_profile_result):
     assert "skew +0.30" in html_out
 
 
+def test_to_html_reports_groups_omitted_by_display_cap(mock_profile_result):
+    dimension = mock_profile_result["dimensions"][0]
+    dimension["groups"] = [
+        {
+            "label": f"Group {index}",
+            "share": 1 / 15,
+            "count": 10,
+            "ci_low": None,
+            "ci_high": None,
+        }
+        for index in range(15)
+    ]
+
+    html_out = to_html(mock_profile_result)
+
+    assert "Group 11" in html_out
+    assert "Group 12" not in html_out
+    assert '<div class="dim-more">… and 3 more groups</div>' in html_out
+
+
 def test_to_html_renders_proxy_hints(mock_profile_result):
     mock_profile_result["proxy_hints"] = [
         {"a": "sex", "b": "region", "p_value": 1.64e-22, "cramers_v": 0.98}


### PR DESCRIPTION
Closes #433.

Adds the missing omitted-group notice to Python and browser HTML exports and documents the shared 12-group display contract.

Validation: `make check` (328 passed, 10 skipped).
