### PR TITLE
codeowners issue fixed

### DIFF
--- a/.github/workflows/codeowners-access.yml
+++ b/.github/workflows/codeowners-access.yml
@@ -27,6 +27,7 @@ permissions:
 
 jobs:
   check-write-access:
+    if: github.repository == 'yakew7/Fair-Code'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

The codeowners access script, when not run on the main repo, failed (because people don't have access on the fork ofc). Fixed this by adding a simple condition so it only runs on the main repo and not on any other fork. 

## Type

- [ ] Audit
- [ ] Explainer
- [x] Bug fix
- [ ] Other

Just found it annoying as it filled my mailbox every now and then. 