### PR TITLE
Fix: render_terminal_png.py leaks raw traceback for missing input file

### DIFF
--- a/scripts/render_terminal_png.py
+++ b/scripts/render_terminal_png.py
@@ -67,7 +67,11 @@ def main():
     if len(sys.argv) != 3:
         print(f"usage: {sys.argv[0]} <input.txt> <output.png>", file=sys.stderr)
         raise SystemExit(2)
-    text = Path(sys.argv[1]).read_text()
+    try:
+        text = Path(sys.argv[1]).read_text()
+    except FileNotFoundError:
+        print(f"error: {sys.argv[1]} not found", file=sys.stderr)
+        raise SystemExit(2)
     render(text, sys.argv[2])
 
 


### PR DESCRIPTION
Fixes `render_terminal_png.py` to handle missing input files cleanly instead of leaking a raw Python traceback.

## Summary

Handles missing input files gracefully by printing `error: <path> not found` to stderr and exiting with code 2, matching the script's existing usage-error behavior.

## Type

- [ ] Audit
- [ ] Explainer
- [x] Bug fix
- [ ] Other

---

## Audit checklist

<!-- Skip this section if you're submitting an explainer or bug fix -->

- [ ] I opened or linked a corresponding issue first
- [ ] The folder is named after the domain, not the dataset
- [ ] `unfair.py` includes protected attributes and prints the required output format
- [ ] `fair.py` removes protected attributes and identified proxy variables
- [ ] Both scripts use `random_state=42` and an 80/20 train/test split
- [ ] Proxy variables were actually tested, not just guessed
- [ ] `unfair.png` and `fair.png` are included as PNG screenshots
- [ ] The dataset is public and accessible without login or payment
- [ ] The dataset file is included, or `DATA.md` is included if the file is too large
- [ ] `README.md` includes the new results row and audit section
- [ ] A notebook was added if the audit benefits from one

**Before fairness gap:** <!-- e.g. 86.77% -->

**After fairness gap:** <!-- e.g. 15.69% -->

**Reduction:** <!-- e.g. 71% -->

**Protected attribute(s):** <!-- e.g. Race -->

**Proxy variables dropped:** <!-- e.g. CustodyStatus -->

---

## Explainer checklist

<!-- Skip this section if you're submitting an audit or bug fix -->

- [ ] The file is in `explainers/` and uses lowercase hyphenated naming
- [ ] It includes a plain-language definition
- [ ] It uses a real example from this repo or a documented real-world case
- [ ] It includes runnable Python detection or measurement code
- [ ] It acknowledges limitations or trade-offs
- [ ] It links to related explainers or repo projects
- [ ] It includes 2-3 primary sources
- [ ] The Explainers table in `README.md` was updated

---

## Linked issue

Closes #460