### PR TITLE
Update new_explainer.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_explainer.yml
+++ b/.github/ISSUE_TEMPLATE/new_explainer.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Open this before writing anything. Check the `explainers/` folder first - proxy variables, equalized odds, sampling bias, SHAP values, disparate impact, fairness metric conflicts, and calibration are already done.
+        Open this before writing anything. Check the [Explainers table in the README](../blob/main/README.md#explainers) or the `explainers/` folder first to make sure this concept isn't already covered - a hardcoded list here would only go stale as more explainers ship.
 
         ✅ Explainers are fully open. If your explainer quotes a Fair Code benchmark result, use the current numbers in `results/` (or `paper/results-frozen/` if you specifically want the earlier reference snapshot) and say which one. See [CLAUDE.md](../blob/main/CLAUDE.md).
 


### PR DESCRIPTION
Fix new_explainer.yml's stale "already done" explainer list (closes #464)

The line named only the first 7 explainers ever added, out of 53 real
ones - it was never updated as the project grew, and
scripts/check_explainer_count.py doesn't scan .github/ISSUE_TEMPLATE/*.yml
so it went unguarded. Replaced the hardcoded list with a link to the
README's Explainers table, which can't drift the same way.
