### PR TITLE
fix: make setup install the benchmark extra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:  ## Show the available targets
 		awk 'BEGIN{FS = ":.*?## "}{printf "  %-16s %s\n", $$1, $$2}'
 
 setup:  ## Install the package plus the dev tools (pytest, pytest-cov, pre-commit, ruff)
-	$(PY) -m pip install -e ".[excel,parquet,proxy,mcp]" pytest pytest-cov pre-commit ruff
+	$(PY) -m pip install -e ".[excel,parquet,proxy,mcp,benchmark]" pytest pytest-cov pre-commit ruff
 
 test:  ## Run the full test suite (mirrors CI)
 	$(PY) -m pytest tests/ -q


### PR DESCRIPTION
Makefile's setup target installed .[excel,parquet,proxy,mcp] but never .[benchmark] (scikit-learn, pyyaml, fairlearn, matplotlib), even though CI's own benchmark-harness job installs it separately and CONTRIBUTING.md documents `make setup` as the one-line "install everything you need" step.

A contributor following that step exactly ends up with tests/test_benchmark.py, test_strategies.py, test_models.py, test_figures.py, and test_cli.py's benchmark subcommand tests all silently skipped via pytest.importorskip - a large swath of the suite CI actually runs, with nothing telling them that happened.

Add benchmark to setup's extras list, matching what CI installs.

Fixes #473

## Summary

<!-- One sentence: e.g. "Adds HMDA mortgage lending bias audit" or "Adds demographic parity explainer" -->

## Type

- [ ] Audit
- [ ] Explainer
- [ ] Bug fix
- [ ] Other

---

## Audit checklist

<!-- Skip this section if you're submitting an explainer or bug fix -->

- [ ] I opened or linked a corresponding issue first
- [ ] The folder is named after the domain, not the dataset
- [ ] `unfair.py` includes protected attributes and prints the required output format
- [ ] `fair.py` removes protected attributes and identified proxy variables
- [ ] Both scripts use `random_state=42` and an 80/20 train/test split
- [ ] Proxy variables were actually tested, not just guessed
- [ ] `unfair.png` and `fair.png` are included as PNG screenshots
- [ ] The dataset is public and accessible without login or payment
- [ ] The dataset file is included, or `DATA.md` is included if the file is too large
- [ ] `README.md` includes the new results row and audit section
- [ ] A notebook was added if the audit benefits from one

**Before fairness gap:** <!-- e.g. 86.77% -->

**After fairness gap:** <!-- e.g. 15.69% -->

**Reduction:** <!-- e.g. 71% -->

**Protected attribute(s):** <!-- e.g. Race -->

**Proxy variables dropped:** <!-- e.g. CustodyStatus -->

---

## Explainer checklist

<!-- Skip this section if you're submitting an audit or bug fix -->

- [ ] The file is in `explainers/` and uses lowercase hyphenated naming
- [ ] It includes a plain-language definition
- [ ] It uses a real example from this repo or a documented real-world case
- [ ] It includes runnable Python detection or measurement code
- [ ] It acknowledges limitations or trade-offs
- [ ] It links to related explainers or repo projects
- [ ] It includes 2-3 primary sources
- [ ] The Explainers table in `README.md` was updated

---

## Linked issue

<!-- Every PR should have a corresponding issue. Example: "Closes #12" -->

Closes #
