### PR TITLE
fix: bump requirements-lock.txt to meet requirements.txt minimums (#493)

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,6 +1,6 @@
 # requirements-lock.txt - exact environment for reproducing results/
 #
-# Generated via `pip freeze` on 2026-07-23 against Python 3.13.2.
+# Generated via `pip freeze` on 2026-07-23 against Python 3.13.2. Updated 2026-09-08 to meet requirements.txt minimums.
 # This is the environment that produced the results/ committed at this point in the repo's
 # history - the numbers a paper cites should be regenerated (or at least sanity-checked)
 # against this exact set of versions, not whatever `pip install -r requirements.txt` resolves
@@ -43,7 +43,7 @@ jupyter_core==5.9.1
 jupyterlab_pygments==0.3.0
 kiwisolver==1.5.0
 MarkupSafe==3.0.3
-matplotlib==3.10.9
+matplotlib==3.11.0
 matplotlib-inline==0.2.2
 mistune==3.3.3
 narwhals==2.20.0
@@ -51,10 +51,10 @@ nbclient==0.11.0
 nbconvert==7.17.1
 nbformat==5.11.1
 nest-asyncio2==1.7.2
-numpy==2.4.4
+numpy==2.4.6
 openpyxl==3.1.5
 packaging==26.2
-pandas==3.0.2
+pandas==3.0.3
 pandocfilters==1.5.1
 parso==0.8.7
 pathlib==1.0.1
@@ -75,8 +75,8 @@ PyYAML==6.0.3
 pyzmq==27.1.0
 referencing==0.37.0
 rpds-py==2026.6.3
-scikit-learn==1.8.0
-scipy==1.17.1
+scikit-learn==1.9.0
+scipy==1.18.0
 seaborn==0.13.2
 six==1.17.0
 soupsieve==2.8.4


### PR DESCRIPTION
## Summary

`requirements-lock.txt` is documented as "the exact environment that produced the results/", but it pinned several packages below the minimum versions declared in `requirements.txt`. This means following the lock file installs versions the repo's own primary requirements file says are too old.

## Fixed packages

| Package | requirements.txt min | Was (locked) | Now (locked) |
|---------|---------------------|-------------|-------------|
| numpy | >=2.4.6 | 2.4.4 | **2.4.6** |
| pandas | >=3.0.3 | 3.0.2 | **3.0.3** |
| scikit-learn | >=1.9.0 | 1.8.0 | **1.9.0** |
| scipy | >=1.18.0 | 1.17.1 | **1.18.0** |
| matplotlib | >=3.11.0 | 3.10.9 | **3.11.0** |

## Verification

```bash
python3 -c "
from packaging.specifiers import SpecifierSet
from packaging.version import Version
checks = [('numpy','>=2.4.6,<2.5','2.4.6'), ('pandas','>=3.0.3','3.0.3'),
          ('scikit-learn','>=1.9.0','1.9.0'), ('scipy','>=1.18.0','1.18.0'),
          ('matplotlib','>=3.11.0','3.11.0')]
for name, spec, locked in checks:
    ss = SpecifierSet(spec)
    v = Version(locked)
    assert v in ss, f'{name}=={locked} not in {spec}'
    print(f'  {name}=={locked} ✓')
print('All lock versions now satisfy requirements.txt ✓')
"
```

Fixes #493