### PR TITLE
docs: fix SPEC.md's stale prefix-match worked example

### DIFF
--- a/faircode/SPEC.md
+++ b/faircode/SPEC.md
@@ -28,8 +28,11 @@ that is what the `unfair.py` / `fair.py` audits do. The Profiler answers a diffe
 Token boundaries are what stop `age` from matching `Agency_Text` or `Language`.
 
 A keyword matches a token by **exact match** when the keyword is <4 chars, or **prefix match** when
-it is ≥4 chars (prefix, not substring - so `age` never matches `agency`, but `statecode` matches
-`state`). Classify by the **first** keyword list that matches any token (order matters):
+it is ≥4 chars (prefix, not substring - so `age` never matches `agency`, but `zipcode` matches
+`zip`). A small set of keywords (`race`, `state`, `city`, `region`, `country` -
+`detect.EXACT_ONLY_KEYWORDS`) are exact-match-only regardless of length, since their common prefixes
+false-positive too easily (`statecode` would otherwise match `state`, `statement`/`stateless` would
+too). Classify by the **first** keyword list that matches any token (order matters):
 
 | Dimension   | Keywords                                                                 |
 |-------------|--------------------------------------------------------------------------|


### PR DESCRIPTION
The fix for #404 added EXACT_ONLY_KEYWORDS = {race, state, city, region, country} to detect.py, forcing exact-match-only for those five keywords to stop state from matching statement/stateless. That fix broke this paragraph's own worked example (statecode no longer matches state - classify_name('statecode') returns None) but nobody updated the text.

  $ python3 -c "from faircode.detect import classify_name; print(classify_name('statecode'))"
  None

Swapped the example to zipcode/zip (confirmed: classify_name('zipcode') -> 'geography', and zip is not in EXACT_ONLY_KEYWORDS) and, per the issue's second suggested fix, also documented the exact-match carve-out list inline so this doesn't drift again the next time a keyword is added to it.

Fixes #489

## Summary

<!-- One sentence: e.g. "Adds HMDA mortgage lending bias audit" or "Adds demographic parity explainer" -->

## Type

- [ ] Audit
- [ ] Explainer
- [ ] Bug fix
- [ ] Other

---

## Audit checklist

<!-- Skip this section if you're submitting an explainer or bug fix -->

- [ ] I opened or linked a corresponding issue first
- [ ] The folder is named after the domain, not the dataset
- [ ] `unfair.py` includes protected attributes and prints the required output format
- [ ] `fair.py` removes protected attributes and identified proxy variables
- [ ] Both scripts use `random_state=42` and an 80/20 train/test split
- [ ] Proxy variables were actually tested, not just guessed
- [ ] `unfair.png` and `fair.png` are included as PNG screenshots
- [ ] The dataset is public and accessible without login or payment
- [ ] The dataset file is included, or `DATA.md` is included if the file is too large
- [ ] `README.md` includes the new results row and audit section
- [ ] A notebook was added if the audit benefits from one

**Before fairness gap:** <!-- e.g. 86.77% -->

**After fairness gap:** <!-- e.g. 15.69% -->

**Reduction:** <!-- e.g. 71% -->

**Protected attribute(s):** <!-- e.g. Race -->

**Proxy variables dropped:** <!-- e.g. CustodyStatus -->

---

## Explainer checklist

<!-- Skip this section if you're submitting an audit or bug fix -->

- [ ] The file is in `explainers/` and uses lowercase hyphenated naming
- [ ] It includes a plain-language definition
- [ ] It uses a real example from this repo or a documented real-world case
- [ ] It includes runnable Python detection or measurement code
- [ ] It acknowledges limitations or trade-offs
- [ ] It links to related explainers or repo projects
- [ ] It includes 2-3 primary sources
- [ ] The Explainers table in `README.md` was updated

---

## Linked issue

<!-- Every PR should have a corresponding issue. Example: "Closes #12" -->

Closes #
