### PR TITLE
feat: add 'make audits' and fold it into 'make check'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 .DEFAULT_GOAL := help
 PY := python3
 
-.PHONY: help setup test coverage build-explainers favicons fix-explainer-count lint check
+.PHONY: help setup test coverage build-explainers favicons fix-explainer-count lint audits check
 
 help:  ## Show the available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | \
@@ -35,5 +35,27 @@ lint:  ## Enforce the em-dash-free rule + check for broken doc links + ruff (mir
 	$(PY) scripts/check_broken_links.py
 	ruff check faircode scripts tests
 
-check: lint test  ## Run everything CI runs (lint + full test suite)
+audits:  ## Run every audit's unfair.py/fair.py + the CLI smoke tests (mirrors audits.yml's required run-audits job, plus profiler/benchmark-harness's CLI steps)
+	@set -e; \
+	for d in "COMPAS" "AI Fair Recruitment" "German Credit Lending" "Insurance Denial" \
+	         "Benefits Denial" "Healthcare Readmission" "Tenant Screening"; do \
+		echo "== $$d - unfair.py =="; \
+		$(PY) "$$d/unfair.py"; \
+		echo "== $$d - fair.py =="; \
+		$(PY) "$$d/fair.py"; \
+	done
+	@echo "== CLI smoke test: faircode profile =="
+	faircode profile "Insurance Denial/insurance.csv"
+	faircode profile "Benefits Denial/adult.csv" --json > /dev/null
+	@echo "== CLI smoke test: faircode benchmark =="
+	@tmp=$$(mktemp -d); \
+	faircode benchmark "German Credit Lending/audit.yaml" \
+		--n-resamples 100 --n-permutations 100 --no-plots \
+		--out "$$tmp"; \
+	test -s "$$tmp/results_fairness.csv"; \
+	test -s "$$tmp/results_performance.csv"; \
+	echo "Benchmark harness smoke test passed: $$(wc -l < "$$tmp/results_fairness.csv") fairness rows written"; \
+	rm -rf "$$tmp"
+
+check: lint test audits  ## Run everything CI runs (lint + full test suite + audits/CLI smoke tests)
 	@echo "All checks passed."


### PR DESCRIPTION
Makefile's header claims it 'reproduces locally what CI runs (audits.yml, lint.yml, build-explainers.yml)', and run-audits is a required status check, but no target ever ran any audit's unfair.py/fair.py or the faircode profile/faircode benchmark CLI smoke tests audits.yml's run-audits/profiler/benchmark-harness jobs actually run - so 'make check' could pass fully green locally while those would still fail in CI.

New 'audits' target runs, in order: all 7 audits' unfair.py then fair.py (matching run-audits' matrix exactly), the two 'faircode profile' smoke-test invocations (profiler job), and the 'faircode benchmark' end-to-end smoke test on German Credit Lending with the same --n-resamples/--n-permutations/--no-plots CI uses, checking both output CSVs are non-empty (benchmark-harness job). Folded into 'check' (setup already installs the benchmark extra, since #473).

Verification: ran 'make audits' end-to-end - exit 0, all 7 audit folders executed (confirmed via grep on captured output, not just the tail), CLI smoke tests both ran, benchmark harness wrote 91 fairness rows. Then deliberately broke COMPAS/unfair.py (replaced with a bare sys.exit(1)) and reran - exit code 2, confirming a real failure actually breaks the target rather than silently passing; restored the original file and confirmed git diff is clean afterward. ruff check and both doc-lint scripts still pass.

Fixes #492

## Summary

<!-- One sentence: e.g. "Adds HMDA mortgage lending bias audit" or "Adds demographic parity explainer" -->

## Type

- [ ] Audit
- [ ] Explainer
- [ ] Bug fix
- [ ] Other

---

## Audit checklist

<!-- Skip this section if you're submitting an explainer or bug fix -->

- [ ] I opened or linked a corresponding issue first
- [ ] The folder is named after the domain, not the dataset
- [ ] `unfair.py` includes protected attributes and prints the required output format
- [ ] `fair.py` removes protected attributes and identified proxy variables
- [ ] Both scripts use `random_state=42` and an 80/20 train/test split
- [ ] Proxy variables were actually tested, not just guessed
- [ ] `unfair.png` and `fair.png` are included as PNG screenshots
- [ ] The dataset is public and accessible without login or payment
- [ ] The dataset file is included, or `DATA.md` is included if the file is too large
- [ ] `README.md` includes the new results row and audit section
- [ ] A notebook was added if the audit benefits from one

**Before fairness gap:** <!-- e.g. 86.77% -->

**After fairness gap:** <!-- e.g. 15.69% -->

**Reduction:** <!-- e.g. 71% -->

**Protected attribute(s):** <!-- e.g. Race -->

**Proxy variables dropped:** <!-- e.g. CustodyStatus -->

---

## Explainer checklist

<!-- Skip this section if you're submitting an audit or bug fix -->

- [ ] The file is in `explainers/` and uses lowercase hyphenated naming
- [ ] It includes a plain-language definition
- [ ] It uses a real example from this repo or a documented real-world case
- [ ] It includes runnable Python detection or measurement code
- [ ] It acknowledges limitations or trade-offs
- [ ] It links to related explainers or repo projects
- [ ] It includes 2-3 primary sources
- [ ] The Explainers table in `README.md` was updated

---

## Linked issue

<!-- Every PR should have a corresponding issue. Example: "Closes #12" -->

Closes #
