### PR TITLE
docs: fix SPEC.md's stale proxy_hints parameter description

### DIFF
--- a/faircode/SPEC.md
+++ b/faircode/SPEC.md
@@ -418,10 +418,10 @@ parity obligation of its own - there is no equivalent MCP surface for the JS eng
 The first three tools accept `overrides` (the section 1 `{column: kind}` map, as a JSON object rather
 than repeated `--map COL=KIND` strings) and the relevant section 7 thresholds by name.
 `profile_dataset` also accepts `cross` and `reference_path`, matching `profile`'s `--cross` and
-`--reference`; `compare_datasets` does not, matching `compare`'s own flag set. `proxy_hints` only
-exposes `min_share`/`min_group_size` - the two thresholds that feed dimension detection - since
-`intersection_floor`/`imbalance_flag`/`missing_flag` affect intersections/flags, which this tool
-never touches.
+`--reference`; `compare_datasets` does not, matching `compare`'s own flag set. `proxy_hints` takes no
+threshold parameters at all - only `path`, `overrides`, and `held_out_with` - since it only surfaces
+candidate proxy pairs for a human/agent to review, not a scored or filtered result the section 7
+thresholds would narrow.
 
 An anticipated failure (an unreadable path, an unknown `overrides` column, `proxy_hints` without
 the `proxy` extra installed) is raised inside the tool as a plain Python exception and converted to


### PR DESCRIPTION
A previous fix removed min_share/min_group_size from _proxy_hints_impl and the registered proxy_hints MCP tool entirely, but never updated this SPEC.md paragraph - it now documents parameters that don't exist, so following it produces a hard TypeError:

  $ python3 -c "
  from faircode.mcp_server import _proxy_hints_impl
  _proxy_hints_impl('x.csv', min_share=0.1)
  "
  TypeError: _proxy_hints_impl() got an unexpected keyword argument 'min_share'

Confirmed current signature is (path, overrides=None, held_out_with=None) and rewrote the paragraph to match - proxy_hints takes no threshold parameters since it surfaces candidate proxy pairs for review, not a scored/filtered result the section 7 thresholds would narrow.

Fixes #499

## Summary

<!-- One sentence: e.g. "Adds HMDA mortgage lending bias audit" or "Adds demographic parity explainer" -->

## Type

- [ ] Audit
- [ ] Explainer
- [ ] Bug fix
- [ ] Other

---

## Audit checklist

<!-- Skip this section if you're submitting an explainer or bug fix -->

- [ ] I opened or linked a corresponding issue first
- [ ] The folder is named after the domain, not the dataset
- [ ] `unfair.py` includes protected attributes and prints the required output format
- [ ] `fair.py` removes protected attributes and identified proxy variables
- [ ] Both scripts use `random_state=42` and an 80/20 train/test split
- [ ] Proxy variables were actually tested, not just guessed
- [ ] `unfair.png` and `fair.png` are included as PNG screenshots
- [ ] The dataset is public and accessible without login or payment
- [ ] The dataset file is included, or `DATA.md` is included if the file is too large
- [ ] `README.md` includes the new results row and audit section
- [ ] A notebook was added if the audit benefits from one

**Before fairness gap:** <!-- e.g. 86.77% -->

**After fairness gap:** <!-- e.g. 15.69% -->

**Reduction:** <!-- e.g. 71% -->

**Protected attribute(s):** <!-- e.g. Race -->

**Proxy variables dropped:** <!-- e.g. CustodyStatus -->

---

## Explainer checklist

<!-- Skip this section if you're submitting an audit or bug fix -->

- [ ] The file is in `explainers/` and uses lowercase hyphenated naming
- [ ] It includes a plain-language definition
- [ ] It uses a real example from this repo or a documented real-world case
- [ ] It includes runnable Python detection or measurement code
- [ ] It acknowledges limitations or trade-offs
- [ ] It links to related explainers or repo projects
- [ ] It includes 2-3 primary sources
- [ ] The Explainers table in `README.md` was updated

---

## Linked issue

<!-- Every PR should have a corresponding issue. Example: "Closes #12" -->

Closes #
