### PR TITLE
fix: check_generated_files_current.py now rebuilds from source, not f…

### DIFF
--- a/scripts/check_generated_files_current.py
+++ b/scripts/check_generated_files_current.py
@@ -3,10 +3,12 @@
 llms-full.txt) or the MCP results-frozen mirror (faircode/_results_frozen/)
 are out of date relative to their sources.
 
-Used by .github/workflows/build-explainers.yml, run *after* the workflow's
-own `build_explainers.py`/`generate_og_images.py`/
-`freeze_paper_results.mirror_for_mcp()` steps have already regenerated
-everything fresh into the working tree.
+Used by .github/workflows/build-explainers.yml. Runs its own fresh
+regeneration internally (see "self-sufficient" below), so it no longer
+depends on the workflow's own build_explainers.py/generate_og_images.py/
+freeze_paper_results.mirror_for_mcp() steps having run first - though CI
+still runs those first anyway, since the workflow's later steps assume a
+built working tree either way.
 
 Text-based generated files (explainer HTML, explainers-data.js,
 sitemap.xml, llms-full.txt, faircode/_results_frozen/*.csv) are compared
@@ -48,6 +50,16 @@ and has the right dimensions; `tests/test_generate_images.py` already
 verifies the *generator* satisfies that in a temp directory, so this
 script checks the same thing for what's actually committed.
 
+This script is self-sufficient: it builds a fresh copy of the site itself
+(via `git worktree`, with every currently tracked file's working-tree
+content copied on top of the HEAD checkout, so uncommitted edits to an
+already-tracked source file are what gets built) and compares the real
+working tree against that regeneration - not against what's committed at
+HEAD. Editing an explainer's .md without running `make build-explainers`
+afterward is exactly the case this now catches; it no longer needs to run
+after CI's own build_explainers.py/generate_og_images.py steps to be
+meaningful, though CI still runs it there too.
+
 Run locally:  python3 scripts/check_generated_files_current.py
 Exit code:    0 = everything current, 1 = something is genuinely stale.
 """
@@ -55,8 +67,11 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
+from contextlib import ExitStack
 from pathlib import Path
 
 from PIL import Image
@@ -104,25 +119,73 @@ def _expected_og_slugs():
     return ["home", "profiler"] + [entry["slug"] for entry in entries]
 
 
+def _fresh_build_dir(stack):
+    """Returns a Path to a real regeneration of the site, built from what's
+    actually on disk right now - not from HEAD. `git worktree add` gives a
+    checkout backed by the same object database/history as ROOT (so
+    git-log-derived dates in build_explainers.py resolve identically to a
+    regeneration done in ROOT itself), then every currently tracked file's
+    *working-tree* content is copied on top of that HEAD checkout, so
+    uncommitted edits to an already-tracked source file are what gets
+    built - exactly the scenario in the bug report this fixes. A brand new,
+    never-`git add`-ed file isn't covered by that overlay (there's nothing
+    to `git ls-files` yet), which matches this script's pre-existing
+    handling of that case below (falls through to "not produced by a fresh
+    regeneration", since a file with no source in the fresh build can't
+    have been generated there).
+
+    `stack` is an ExitStack the caller uses to guarantee the worktree is
+    cleaned up even if a later step raises.
+    """
+    tmp = Path(tempfile.mkdtemp(prefix="faircode-freshbuild-"))
+    stack.callback(lambda: subprocess.run(
+        ["git", "worktree", "remove", "--force", str(tmp)],
+        cwd=ROOT, capture_output=True, check=False,
+    ))
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", "--quiet", str(tmp), "HEAD"],
+        cwd=ROOT, check=True,
+    )
+
+    tracked = subprocess.run(
+        ["git", "ls-files"], cwd=ROOT, capture_output=True, text=True, check=True
+    ).stdout.splitlines()
+    for rel in tracked:
+        if not rel.strip():
+            continue
+        src, dst = ROOT / rel, tmp / rel
+        if src.is_file():
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(src, dst)
+
+    for cmd in (
+        [sys.executable, "scripts/build_explainers.py"],
+        [sys.executable, "scripts/generate_og_images.py"],
+        [sys.executable, "-c",
+         "from scripts.freeze_paper_results import mirror_for_mcp; mirror_for_mcp()"],
+    ):
+        subprocess.run(cmd, cwd=tmp, check=True, capture_output=True, text=True)
+
+    return tmp
+
+
 def main():
     stale = []
 
-    for pattern in TEXT_GLOBS:
-        for path in _tracked_paths(pattern):
-            rel = path.relative_to(ROOT)
-            show = subprocess.run(
-                ["git", "show", f"HEAD:{rel.as_posix()}"],
-                cwd=ROOT, capture_output=True, text=True, check=False,
-            )
-            if show.returncode != 0:
-                # Staged but never committed (e.g. running this locally
-                # before the first commit of a brand new file) - trivially
-                # differs from "nothing at HEAD", not a normalization case.
-                stale.append((rel, "not yet committed"))
-                continue
-            fresh = path.read_text(encoding="utf-8")
-            if _normalize_dates(show.stdout) != _normalize_dates(fresh):
-                stale.append((rel, "content differs from a fresh regeneration"))
+    with ExitStack() as stack:
+        fresh_dir = _fresh_build_dir(stack)
+
+        for pattern in TEXT_GLOBS:
+            for path in _tracked_paths(pattern):
+                rel = path.relative_to(ROOT)
+                fresh_path = fresh_dir / rel
+                if not fresh_path.is_file():
+                    stale.append((rel, "not produced by a fresh regeneration"))
+                    continue
+                working_tree = path.read_text(encoding="utf-8")
+                fresh = fresh_path.read_text(encoding="utf-8")
+                if _normalize_dates(fresh) != _normalize_dates(working_tree):
+                    stale.append((rel, "content differs from a fresh regeneration"))
 
     for theme_dir in ("assets/og", "assets/og-light"):
         for slug in _expected_og_slugs():

--- a/tests/test_check_generated_files_current.py
+++ b/tests/test_check_generated_files_current.py
@@ -17,15 +17,27 @@ def _script():
     return importlib.import_module("scripts.check_generated_files_current")
 
 
-def _fake_run(ls_files_output, show_returncode=0, show_stdout=""):
+def _fake_run(ls_files_output):
     def run(cmd, cwd=None, capture_output=True, text=True, check=False):
         import types
         if cmd[:2] == ["git", "ls-files"]:
             return types.SimpleNamespace(returncode=0, stdout=ls_files_output)
-        if cmd[:2] == ["git", "show"]:
-            return types.SimpleNamespace(returncode=show_returncode, stdout=show_stdout)
         raise AssertionError(f"unexpected subprocess call: {cmd}")
     return run
+
+
+def _fake_fresh_build_dir(tmp_path, files):
+    """Monkeypatches script._fresh_build_dir to skip the real git-worktree
+    checkout and subprocess build steps entirely, returning a plain
+    directory pre-populated with `files` (rel path -> content) instead -
+    the fresh-regeneration equivalent of _empty_repo() below, so tests
+    still don't need a real git repository."""
+    fresh = tmp_path / "_fresh"
+    for rel, content in files.items():
+        path = fresh / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    return lambda stack: fresh
 
 
 def _empty_repo(tmp_path, monkeypatch, script):
@@ -70,10 +82,11 @@ def test_main_flags_a_stale_text_file(tmp_path, monkeypatch, capsys):
     _empty_repo(tmp_path, monkeypatch, script)
     monkeypatch.setattr(script, "TEXT_GLOBS", ["sitemap.xml"])
     monkeypatch.setattr(script, "_expected_og_slugs", lambda: [])
-    (tmp_path / "sitemap.xml").write_text("fresh content\n", encoding="utf-8")
+    (tmp_path / "sitemap.xml").write_text("stale working-tree content\n", encoding="utf-8")
+    monkeypatch.setattr(script.subprocess, "run", _fake_run("sitemap.xml\n"))
     monkeypatch.setattr(
-        script.subprocess, "run",
-        _fake_run("sitemap.xml\n", show_returncode=0, show_stdout="stale committed content\n"))
+        script, "_fresh_build_dir",
+        _fake_fresh_build_dir(tmp_path, {"sitemap.xml": "freshly regenerated content\n"}))
 
     exit_code = script.main()
 
@@ -82,15 +95,16 @@ def test_main_flags_a_stale_text_file(tmp_path, monkeypatch, capsys):
     assert "sitemap.xml: content differs from a fresh regeneration" in captured.out
 
 
-def test_main_passes_when_text_file_matches_head(tmp_path, monkeypatch, capsys):
+def test_main_passes_when_text_file_matches_fresh_regeneration(tmp_path, monkeypatch, capsys):
     script = _script()
     _empty_repo(tmp_path, monkeypatch, script)
     monkeypatch.setattr(script, "TEXT_GLOBS", ["sitemap.xml"])
     monkeypatch.setattr(script, "_expected_og_slugs", lambda: [])
     (tmp_path / "sitemap.xml").write_text("same content\n", encoding="utf-8")
+    monkeypatch.setattr(script.subprocess, "run", _fake_run("sitemap.xml\n"))
     monkeypatch.setattr(
-        script.subprocess, "run",
-        _fake_run("sitemap.xml\n", show_returncode=0, show_stdout="same content\n"))
+        script, "_fresh_build_dir",
+        _fake_fresh_build_dir(tmp_path, {"sitemap.xml": "same content\n"}))
 
     exit_code = script.main()
 
@@ -98,21 +112,53 @@ def test_main_passes_when_text_file_matches_head(tmp_path, monkeypatch, capsys):
     assert "up to date" in capsys.readouterr().out
 
 
-def test_main_flags_a_file_not_yet_committed(tmp_path, monkeypatch, capsys):
+def test_main_flags_a_file_not_produced_by_a_fresh_regeneration(tmp_path, monkeypatch, capsys):
     script = _script()
     _empty_repo(tmp_path, monkeypatch, script)
     monkeypatch.setattr(script, "TEXT_GLOBS", ["sitemap.xml"])
     monkeypatch.setattr(script, "_expected_og_slugs", lambda: [])
-    (tmp_path / "sitemap.xml").write_text("brand new file\n", encoding="utf-8")
-    monkeypatch.setattr(
-        script.subprocess, "run",
-        _fake_run("sitemap.xml\n", show_returncode=1, show_stdout=""))
+    (tmp_path / "sitemap.xml").write_text("tracked, but the fresh build made nothing here\n",
+                                           encoding="utf-8")
+    monkeypatch.setattr(script.subprocess, "run", _fake_run("sitemap.xml\n"))
+    # No "sitemap.xml" key: the fresh regeneration never produced this path.
+    monkeypatch.setattr(script, "_fresh_build_dir", _fake_fresh_build_dir(tmp_path, {}))
 
     exit_code = script.main()
 
     captured = capsys.readouterr()
     assert exit_code == 1
-    assert "sitemap.xml: not yet committed" in captured.out
+    assert "sitemap.xml: not produced by a fresh regeneration" in captured.out
+
+
+def test_main_catches_an_uncommitted_edit_never_rebuilt(tmp_path, monkeypatch, capsys):
+    # Regression test for #502: this script used to diff the working tree
+    # against `git show HEAD:<path>`, which only catches "you forgot to
+    # stage a file that differs from your last commit" - not "your source
+    # and generated output have actually diverged". Editing a source file
+    # without rebuilding, before ever committing anything, used to pass.
+    script = _script()
+    _empty_repo(tmp_path, monkeypatch, script)
+    monkeypatch.setattr(script, "TEXT_GLOBS", ["explainers/demographic-parity.html"])
+    monkeypatch.setattr(script, "_expected_og_slugs", lambda: [])
+    stale_html = (tmp_path / "explainers" / "demographic-parity.html")
+    stale_html.parent.mkdir(parents=True)
+    stale_html.write_text("<p>old content, source .md was edited after this was built</p>\n",
+                           encoding="utf-8")
+    monkeypatch.setattr(
+        script.subprocess, "run", _fake_run("explainers/demographic-parity.html\n"))
+    # A real _fresh_build_dir would rebuild from the edited .md and produce
+    # different HTML; simulate exactly that divergence directly.
+    monkeypatch.setattr(script, "_fresh_build_dir", _fake_fresh_build_dir(tmp_path, {
+        "explainers/demographic-parity.html":
+            "<p>new content, reflects the edited .md source</p>\n",
+    }))
+
+    exit_code = script.main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "explainers/demographic-parity.html: content differs from a fresh regeneration" \
+        in captured.out
 
 
 def test_main_flags_a_missing_og_image(tmp_path, monkeypatch, capsys):
@@ -122,6 +168,7 @@ def test_main_flags_a_missing_og_image(tmp_path, monkeypatch, capsys):
     (tmp_path / "assets" / "explainers-data.json").write_text(
         json.dumps([{"slug": "example"}]), encoding="utf-8")
     monkeypatch.setattr(script.subprocess, "run", _fake_run(""))
+    monkeypatch.setattr(script, "_fresh_build_dir", _fake_fresh_build_dir(tmp_path, {}))
 
     exit_code = script.main()
 
@@ -138,6 +185,7 @@ def test_main_flags_an_og_image_with_wrong_dimensions(tmp_path, monkeypatch, cap
     (tmp_path / "assets" / "explainers-data.json").write_text(
         json.dumps([{"slug": "example"}]), encoding="utf-8")
     monkeypatch.setattr(script.subprocess, "run", _fake_run(""))
+    monkeypatch.setattr(script, "_fresh_build_dir", _fake_fresh_build_dir(tmp_path, {}))
 
     for theme_dir in ("assets/og", "assets/og-light"):
         (tmp_path / theme_dir).mkdir(parents=True)
@@ -159,6 +207,7 @@ def test_main_passes_with_correctly_sized_og_images(tmp_path, monkeypatch, capsy
     (tmp_path / "assets" / "explainers-data.json").write_text(
         json.dumps([{"slug": "example"}]), encoding="utf-8")
     monkeypatch.setattr(script.subprocess, "run", _fake_run(""))
+    monkeypatch.setattr(script, "_fresh_build_dir", _fake_fresh_build_dir(tmp_path, {}))
 
     for theme_dir in ("assets/og", "assets/og-light"):
         (tmp_path / theme_dir).mkdir(parents=True)


### PR DESCRIPTION
…rom HEAD

It only ever diffed the working tree against 'git show HEAD:<path>' - so editing a source .md without running 'make build-explainers' afterward still reported "up to date", as long as nothing was committed yet. Confirmed exactly the issue's repro (git worktree add + append a line to explainers/demographic-parity.md) now correctly fails with 'content differs from a fresh regeneration' where it used to pass.

_fresh_build_dir() now does the real regeneration: a git worktree checked out to HEAD (shares this repo's object database/history, so git-log-derived dates resolve identically to a build done in ROOT itself), with every currently-tracked file's *working-tree* content copied on top before running build_explainers.py, generate_og_images.py, and freeze_paper_results.mirror_for_mcp() inside it - the same sequence build-explainers.yml runs, now run by this script itself instead of assumed to have already happened. The worktree is cleaned up via ExitStack regardless of what happens after.

Updated tests/test_check_generated_files_current.py to monkeypatch _fresh_build_dir directly (pre-populated stub directory) instead of faking 'git show', per the file's own stated testing philosophy of avoiding a real git repo in unit tests. Added a regression test for the exact scenario in the bug report.

Verification: reproduced the issue's exact repro against the unmodified script (confirmed it passed when it shouldn't), then against the fixed script (confirmed it now fails with the right reason). All 9 tests/test_check_generated_files_current.py tests pass; full suite is 402 passed, 1 skipped, 4 failed - the 4 failures are tests/test_xlsx_edge_cases.py, confirmed identical on unmodified main (SheetJS CDN returns HTTP 403 in this sandbox), unrelated to this change.

Fixes #502

## Summary

<!-- One sentence: e.g. "Adds HMDA mortgage lending bias audit" or "Adds demographic parity explainer" -->

## Type

- [ ] Audit
- [ ] Explainer
- [ ] Bug fix
- [ ] Other

---

## Audit checklist

<!-- Skip this section if you're submitting an explainer or bug fix -->

- [ ] I opened or linked a corresponding issue first
- [ ] The folder is named after the domain, not the dataset
- [ ] `unfair.py` includes protected attributes and prints the required output format
- [ ] `fair.py` removes protected attributes and identified proxy variables
- [ ] Both scripts use `random_state=42` and an 80/20 train/test split
- [ ] Proxy variables were actually tested, not just guessed
- [ ] `unfair.png` and `fair.png` are included as PNG screenshots
- [ ] The dataset is public and accessible without login or payment
- [ ] The dataset file is included, or `DATA.md` is included if the file is too large
- [ ] `README.md` includes the new results row and audit section
- [ ] A notebook was added if the audit benefits from one

**Before fairness gap:** <!-- e.g. 86.77% -->

**After fairness gap:** <!-- e.g. 15.69% -->

**Reduction:** <!-- e.g. 71% -->

**Protected attribute(s):** <!-- e.g. Race -->

**Proxy variables dropped:** <!-- e.g. CustodyStatus -->

---

## Explainer checklist

<!-- Skip this section if you're submitting an audit or bug fix -->

- [ ] The file is in `explainers/` and uses lowercase hyphenated naming
- [ ] It includes a plain-language definition
- [ ] It uses a real example from this repo or a documented real-world case
- [ ] It includes runnable Python detection or measurement code
- [ ] It acknowledges limitations or trade-offs
- [ ] It links to related explainers or repo projects
- [ ] It includes 2-3 primary sources
- [ ] The Explainers table in `README.md` was updated

---

## Linked issue

<!-- Every PR should have a corresponding issue. Example: "Closes #12" -->

Closes #
