### PR TITLE
fix: non-numeric age sentinels get their own categorical group

### DIFF
--- a/assets/profiler-engine.js
+++ b/assets/profiler-engine.js
@@ -452,6 +452,18 @@
     return AGE_BANDS[AGE_BANDS.length - 1] + '+';
   }
 
+  // True only for free text with no embedded number at all (e.g. "unknown",
+  // "prefer not to say") - SPEC.md section 2's "anything else: treat as
+  // categorical" rule for a per-value age rule. False for null/undefined
+  // and for any numeric value, including one embedded in a string - even a
+  // number outside the valid age range, like a -1/999 sentinel, still
+  // counts as "has a number" here and is routed to missing/null, matching
+  // this profiler's prior behavior for range-invalid numeric sentinels.
+  function isCategoricalAgeSentinel(value) {
+    if (value === null || value === undefined || typeof value === 'number') return false;
+    return !/[+-]?\d+(?:\.\d+)?/.test(String(value));
+  }
+
   var AGE_BAND_LABELS = {};
   (function () {
     for (var i = 0; i < AGE_BANDS.length - 1; i++) {
@@ -593,8 +605,20 @@
         var counts = {}, nullCount = 0;
         for (i = 0; i < nums.length; i++) {
           var b = ageBand(nums[i]);
-          if (b === null) nullCount++;
-          else counts[b] = (counts[b] || 0) + 1;
+          if (b !== null) {
+            counts[b] = (counts[b] || 0) + 1;
+          } else if (isCategoricalAgeSentinel(rows[i][name])) {
+            // Non-numeric free text (e.g. "unknown", "prefer not to say") -
+            // SPEC.md section 2's "anything else: treat as categorical"
+            // rule. Distinct from a genuinely missing cell or an
+            // out-of-range numeric sentinel (both still go to nullCount
+            // below): gets its own group instead of silently folding into
+            // missing_pct.
+            var label = String(rows[i][name]).trim();
+            counts[label] = (counts[label] || 0) + 1;
+          } else {
+            nullCount++;
+          }
         }
         var res = analyzeGroups(counts, nTotal, nullCount, skew, minShareThreshold, minGroupSize);
         res.name = name; res.kind = kind;

--- a/faircode/profiler.py
+++ b/faircode/profiler.py
@@ -117,6 +117,21 @@ def _age_to_numeric(value):
     return numeric if math.isfinite(numeric) and numeric >= AGE_BANDS[0] else None
 
 
+def _is_categorical_age_sentinel(value) -> bool:
+    """True only for free text with no embedded number at all (e.g.
+    "unknown", "prefer not to say") - SPEC.md section 2's "anything else:
+    treat as categorical" rule for a per-value age rule. False for
+    None/NaN and for any numeric value, including one embedded in a
+    string - even a number outside the valid age range, like a -1/999
+    sentinel, still counts as "has a number" here and is routed to
+    missing/null, matching this profiler's prior behavior for
+    range-invalid numeric sentinels (see
+    test_negative_age_sentinels_are_missing_instead_of_an_elderly_group)."""
+    if value is None or isinstance(value, (int, float)):
+        return False
+    return re.search(r"[+-]?\d+(?:\.\d+)?", str(value)) is None
+
+
 def _age_band(num) -> str | None:
     if num is None or not math.isfinite(num) or num < AGE_BANDS[0]:
         return None
@@ -210,11 +225,22 @@ def _dimension(df: pd.DataFrame, name: str, kind: str,
         if numeric_vals:
             skewness = _skewness(numeric_vals)
             bands = [_age_band(n) for n in nums]
-            null_count = sum(1 for b in bands if b is None)
+            null_count = 0
             counts: dict = {}
-            for b in bands:
-                if b is not None:
-                    counts[b] = counts.get(b, 0) + 1
+            for value, band in zip(col, bands):
+                if band is not None:
+                    counts[band] = counts.get(band, 0) + 1
+                elif _is_categorical_age_sentinel(value):
+                    # Non-numeric free text (e.g. "unknown", "prefer not to
+                    # say") - SPEC.md section 2's "anything else: treat as
+                    # categorical" rule. Distinct from a genuinely missing
+                    # cell or an out-of-range numeric sentinel (both still
+                    # go to null_count below): gets its own group instead
+                    # of silently folding into missing_pct.
+                    label = str(value).strip()
+                    counts[label] = counts.get(label, 0) + 1
+                else:
+                    null_count += 1
             result = _analyze_groups(counts, n_total, null_count, skewness, min_share, min_group_size)
             result.update({"name": name, "kind": kind})
             return result

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -130,6 +130,37 @@ def test_negative_age_sentinels_are_missing_instead_of_an_elderly_group():
     assert dim["missing_pct"] == 0.6667
 
 
+def test_non_numeric_age_sentinels_get_their_own_categorical_group():
+    # Regression test for #487: free-text age responses with no embedded
+    # number ("unknown", "prefer not to say") used to silently fold into
+    # missing_pct, indistinguishable from a genuinely blank cell -
+    # contradicting SPEC.md section 2's "anything else: treat as
+    # categorical" rule.
+    df = pd.DataFrame({"age": [25, 30, 45, "unknown", "unknown", "unknown",
+                                "prefer not to say", 22, 33, 41]})
+
+    dim = profile(df)["dimensions"][0]
+
+    labels = {group["label"]: group["count"] for group in dim["groups"]}
+    assert labels["unknown"] == 3
+    assert labels["prefer not to say"] == 1
+    assert dim["missing_pct"] == 0.0
+    assert dim["n_groups"] == 5
+
+
+def test_non_numeric_age_sentinels_are_distinct_from_genuine_missing_cells():
+    # A real None/NaN cell must still count toward missing_pct, not get
+    # folded into a categorical sentinel group alongside real free text.
+    df = pd.DataFrame({"age": [25, 30, 45, None, float("nan"), "unknown",
+                                22, 33, 41, 29]})
+
+    dim = profile(df)["dimensions"][0]
+
+    labels = {group["label"]: group["count"] for group in dim["groups"]}
+    assert labels["unknown"] == 1
+    assert dim["missing_pct"] == 0.2
+
+
 def test_skewness_symmetric_is_zero():
     assert abs(_skewness([1, 2, 3, 4, 5])) < 1e-9
 


### PR DESCRIPTION
_age_to_numeric() returned None for both a genuinely missing cell and free text with no embedded number at all (e.g. "unknown", "prefer not to say") - the age-banding loop then counted every None straight into null_count, indistinguishable from real missing data. Contradicted SPEC.md section 2's own documented "anything else: treat as categorical" rule for exactly this case.

  $ python3 -c "
  import pandas as pd
  from faircode.profiler import profile
  df = pd.DataFrame({'age': [25,30,45,'unknown','unknown','unknown','prefer not to say',22,33,41]})
  d = profile(df)['dimensions'][0]
  print(d['n_groups'], d['missing_pct'])
  "
  3 0.4   # (before) - 4 real responses vanish into missing_pct
  5 0.0   # (after)  - 'unknown' (3) and 'prefer not to say' (1) get their own groups

New _is_categorical_age_sentinel() (faircode/profiler.py) / isCategoricalAgeSentinel() (assets/profiler-engine.js) distinguish three cases per unparseable value: None/NaN (missing), a numeric value out of the valid age range like a -1/999 sentinel (also missing - matches this profiler's existing, tested behavior for range-invalid numeric sentinels), and free text with no embedded number at all (categorical). Only the third case gets its own group.

First attempt at this used pd.isna()/typeof-only-numeric as the distinguishing check and broke
test_negative_age_sentinels_are_missing_instead_of_an_elderly_group - a -1 sentinel isn't NaN, so it was wrongly routed to a new '-1' categorical group instead of staying missing. Caught by running the full profiler suite before committing; fixed by checking for an embedded number via the same regex _age_to_numeric()/ageToNumeric() already use, not just NaN-ness.

Verified Python/JS parity directly (not just via the test suite): built a CSV from the issue's exact repro and ran both
faircode.profiler.profile() and 'node scripts/engine-js.js profile' against it - identical n_groups, missing_pct, and group labels/counts on both engines.

Added two regression tests to tests/test_profiler.py: the issue's exact repro, and a mixed case (real None/NaN alongside a text sentinel) confirming missing_pct only counts the genuine blanks. Full suite: tests/test_profiler.py 38/38, tests/test_js_parity.py 21 passed + 1 skipped, full suite 401 passed/1 skipped/4 failed (the 4 are tests/test_xlsx_edge_cases.py, confirmed pre-existing and unrelated - SheetJS CDN blocked in this sandbox).

Known follow-up, out of scope here: _intersections()'s labelize() helper (used by compare(), not profile()) still routes these same sentinel values through ageBand()/None the old way for cross-tabulation purposes. The issue's own repro and acceptance criteria are profile()- only; left as-is rather than silently expanding scope.

Fixes #487

## Summary

<!-- One sentence: e.g. "Adds HMDA mortgage lending bias audit" or "Adds demographic parity explainer" -->

## Type

- [ ] Audit
- [ ] Explainer
- [ ] Bug fix
- [ ] Other

---

## Audit checklist

<!-- Skip this section if you're submitting an explainer or bug fix -->

- [ ] I opened or linked a corresponding issue first
- [ ] The folder is named after the domain, not the dataset
- [ ] `unfair.py` includes protected attributes and prints the required output format
- [ ] `fair.py` removes protected attributes and identified proxy variables
- [ ] Both scripts use `random_state=42` and an 80/20 train/test split
- [ ] Proxy variables were actually tested, not just guessed
- [ ] `unfair.png` and `fair.png` are included as PNG screenshots
- [ ] The dataset is public and accessible without login or payment
- [ ] The dataset file is included, or `DATA.md` is included if the file is too large
- [ ] `README.md` includes the new results row and audit section
- [ ] A notebook was added if the audit benefits from one

**Before fairness gap:** <!-- e.g. 86.77% -->

**After fairness gap:** <!-- e.g. 15.69% -->

**Reduction:** <!-- e.g. 71% -->

**Protected attribute(s):** <!-- e.g. Race -->

**Proxy variables dropped:** <!-- e.g. CustodyStatus -->

---

## Explainer checklist

<!-- Skip this section if you're submitting an audit or bug fix -->

- [ ] The file is in `explainers/` and uses lowercase hyphenated naming
- [ ] It includes a plain-language definition
- [ ] It uses a real example from this repo or a documented real-world case
- [ ] It includes runnable Python detection or measurement code
- [ ] It acknowledges limitations or trade-offs
- [ ] It links to related explainers or repo projects
- [ ] It includes 2-3 primary sources
- [ ] The Explainers table in `README.md` was updated

---

## Linked issue

<!-- Every PR should have a corresponding issue. Example: "Closes #12" -->

Closes #
