### PR TITLE
fix: TargetSpec.compute() now excludes rows with a missing target label

### DIFF
--- a/faircode/benchmark.py
+++ b/faircode/benchmark.py
@@ -60,10 +60,10 @@ def _load_dataset(manifest):
         df = row_filter.apply(df)
     df = df.reset_index(drop=True)
 
-    y = manifest.target.compute(df)
+    y, target_known = manifest.target.compute(df)
 
     protected_masks = {}
-    known_mask = pd.Series(True, index=df.index)
+    known_mask = target_known.copy()
     for pa in manifest.protected_attributes:
         disadv, known = pa.disadvantaged_mask(df)
         protected_masks[pa.name] = disadv

--- a/faircode/manifest.py
+++ b/faircode/manifest.py
@@ -57,17 +57,35 @@ class TargetSpec:
         if self.method == "isin" and self.values is None:
             raise ValueError(f"{self.column}: target method 'isin' needs a 'values' field")
 
-    def compute(self, df: pd.DataFrame) -> pd.Series:
+    def compute(self, df: pd.DataFrame) -> tuple[pd.Series, pd.Series]:
+        """Returns (y, known_mask) - both boolean/int Series aligned to df.
+
+        known_mask is False for rows this target can't classify (a
+        missing/NaN label), mirroring
+        ProtectedAttribute.disadvantaged_mask() below, so the caller can
+        drop them instead of a NaN label silently becoming a plain
+        negative-class (0) row. NaN == value, NaN in [...], and
+        NaN > median all evaluate to False in pandas regardless of method,
+        so known_mask is always just col.notna() - computed once up front
+        rather than per-method.
+        """
         col = df[self.column]
+        known = col.notna()
         if self.method == "binary":
-            return col.astype(int)
-        if self.method == "equals":
-            return (col == self.value).astype(int)
-        if self.method == "isin":
-            return col.isin(self.values).astype(int)
-        if self.method == "above_median":
-            return (col > col.median()).astype(int)
-        raise ValueError(f"unknown target method: {self.method!r}")
+            # .astype(int) alone raises IntCastingNaNError on a NaN cell;
+            # fillna(0) first so a genuinely missing label no longer
+            # crashes here instead of being excluded via known_mask like
+            # every other method already was.
+            y = col.fillna(0).astype(int)
+        elif self.method == "equals":
+            y = (col == self.value).astype(int)
+        elif self.method == "isin":
+            y = col.isin(self.values).astype(int)
+        elif self.method == "above_median":
+            y = (col > col.median()).astype(int)
+        else:
+            raise ValueError(f"unknown target method: {self.method!r}")
+        return y, known
 
 
 @dataclass

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -333,3 +333,38 @@ def test_run_benchmark_wraps_degenerate_zero_row_dataset_with_manifest_path(tmp_
 
     with pytest.raises(ValueError, match=str(audit_dir / "audit.yaml")):
         run_benchmark(root=str(tmp_path), n_resamples=N_RESAMPLES, n_permutations=N_PERMUTATIONS)
+
+
+def test_load_dataset_excludes_rows_with_a_missing_target_label(tmp_path):
+    # Integration regression test for #488: _load_dataset combines
+    # TargetSpec.compute()'s known_mask with the protected-attribute
+    # known_mask it already ANDs together, so a genuinely missing/NaN
+    # target label is dropped the same way an unknown protected-attribute
+    # value already was - not silently scored as a plain negative-class row.
+    from faircode.benchmark import _load_dataset
+
+    audit_dir = tmp_path / "NaN Target Audit"
+    audit_dir.mkdir()
+    pd.DataFrame({
+        "label": [1, 0, 1, np.nan, 0],
+        "g": ["a", "b", "a", "b", "a"],
+        "x": [1, 2, 3, 4, 5],
+    }).to_csv(audit_dir / "toy.csv", index=False)
+    (audit_dir / "audit.yaml").write_text(yaml.dump({
+        "name": "toy",
+        "dataset": {"path": "toy.csv"},
+        "target": {"column": "label", "method": "binary"},
+        "protected_attributes": [
+            {"name": "g", "type": "categorical", "column": "g",
+             "disadvantaged_values": ["a"], "advantaged_values": ["b"]},
+        ],
+        "core_features": ["x"],
+    }))
+
+    manifest = load_manifest(audit_dir / "audit.yaml")
+    df, y, protected_masks = _load_dataset(manifest)
+
+    assert len(df) == 4
+    assert len(y) == 4
+    assert len(protected_masks["g"]) == 4
+    assert 4 not in df.index  # the NaN-label row (original index 3) is gone

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -152,9 +152,37 @@ def test_age_interval_threshold_rejects_a_typo_d_disadvantaged_value():
 # ── TargetSpec / RowFilter / ProtectedAttribute behaviour ───────────────────
 def test_target_spec_methods():
     df = pd.DataFrame({"income": [10, 60, 30, 90], "flag": ["yes", "no", "yes", "no"]})
-    assert TargetSpec("income", "above_median").compute(df).tolist() == [0, 1, 0, 1]
-    assert TargetSpec("flag", "equals", value="yes").compute(df).tolist() == [1, 0, 1, 0]
-    assert TargetSpec("flag", "isin", values=["yes"]).compute(df).tolist() == [1, 0, 1, 0]
+    assert TargetSpec("income", "above_median").compute(df)[0].tolist() == [0, 1, 0, 1]
+    assert TargetSpec("flag", "equals", value="yes").compute(df)[0].tolist() == [1, 0, 1, 0]
+    assert TargetSpec("flag", "isin", values=["yes"]).compute(df)[0].tolist() == [1, 0, 1, 0]
+
+
+def test_target_spec_methods_all_report_known_true_with_no_missing_labels():
+    df = pd.DataFrame({"income": [10, 60, 30, 90], "flag": ["yes", "no", "yes", "no"]})
+    assert TargetSpec("income", "above_median").compute(df)[1].tolist() == [True] * 4
+    assert TargetSpec("flag", "equals", value="yes").compute(df)[1].tolist() == [True] * 4
+    assert TargetSpec("flag", "isin", values=["yes"]).compute(df)[1].tolist() == [True] * 4
+
+
+@pytest.mark.parametrize("method,kwargs", [
+    ("binary", {}),
+    ("equals", {"value": 1}),
+    ("isin", {"values": [1]}),
+    ("above_median", {}),
+])
+def test_target_spec_excludes_missing_labels_via_known_mask(method, kwargs):
+    # Regression test for #488: a NaN row used to silently become a plain
+    # negative-class (0) row for equals/isin/above_median (NaN == value,
+    # NaN in [...], and NaN > median are all False in pandas), and raised
+    # IntCastingNaNError for binary - inconsistent, and neither excludes
+    # the row the way ProtectedAttribute.disadvantaged_mask() already does
+    # for an unknown protected-attribute value.
+    df = pd.DataFrame({"outcome": [1, 0, 1, float("nan"), 0]})
+    y, known = TargetSpec("outcome", method, **kwargs).compute(df)
+    assert known.tolist() == [True, True, True, False, True]
+    # The excluded row's y value is a don't-care placeholder - what matters
+    # is that known_mask flags it, not what y happens to be there.
+    assert len(y) == len(df)
 
 
 def test_row_filter_isin_and_notna():


### PR DESCRIPTION
NaN == value, NaN in [...], and NaN > median all evaluate to False in pandas, so a row with a missing/NaN target label silently became a plain negative-class (0) row for equals/isin/above_median - while method: binary raised IntCastingNaNError on the exact same input, so the four methods weren't even consistent with each other. Neither behavior matched ProtectedAttribute.disadvantaged_mask(), which already returns an explicit known_mask so _load_dataset can drop rows it can't classify.

  $ python3 -c "
  import pandas as pd
  from faircode.manifest import TargetSpec
  df = pd.DataFrame({'outcome':[1,0,1,float('nan'),0]})
  print(TargetSpec(column='outcome', method='equals', value=1).compute(df))
  "
  (before) [1, 0, 1, 0, 0]                    # NaN row silently scored as negative
  (after)  y=[1,0,1,0,0] known=[T,T,T,False,T] # NaN row explicitly flagged

TargetSpec.compute() now returns (y, known_mask), mirroring disadvantaged_mask()'s existing (mask, known) shape exactly. known_mask is col.notna() computed once up front, since all four methods agree on what counts as missing. binary now does col.fillna(0).astype(int) instead of col.astype(int), so a NaN cell no longer crashes - it's excluded via known_mask the same way the other three methods' NaN rows now are, instead of the whole run failing loudly on binary specifically while succeeding silently-wrong on the rest.

faircode/benchmark.py's _load_dataset now starts known_mask from target_known instead of an all-True Series, ANDing it with every protected attribute's known_mask exactly like the existing per-attribute loop already does - one line changed, same pattern already established for protected attributes.

Updated tests/test_manifest.py's three call sites for the new tuple return, added a parametrized test covering all four methods' known_mask behavior on a NaN row, and added an integration test in tests/test_benchmark.py exercising _load_dataset directly end-to-end (a NaN-labeled row goes in, 4 of 5 rows come out, the NaN row's original index is gone) - not just the TargetSpec unit alone. Full suite: 407 passed (+6 over pre-change baseline)/1 skipped/4 failed - the 4 are tests/test_xlsx_edge_cases.py, already confirmed pre-existing and unrelated (SheetJS CDN blocked in this sandbox) in an earlier PR on this branch of work.

Fixes #488

## Summary

<!-- One sentence: e.g. "Adds HMDA mortgage lending bias audit" or "Adds demographic parity explainer" -->

## Type

- [ ] Audit
- [ ] Explainer
- [ ] Bug fix
- [ ] Other

---

## Audit checklist

<!-- Skip this section if you're submitting an explainer or bug fix -->

- [ ] I opened or linked a corresponding issue first
- [ ] The folder is named after the domain, not the dataset
- [ ] `unfair.py` includes protected attributes and prints the required output format
- [ ] `fair.py` removes protected attributes and identified proxy variables
- [ ] Both scripts use `random_state=42` and an 80/20 train/test split
- [ ] Proxy variables were actually tested, not just guessed
- [ ] `unfair.png` and `fair.png` are included as PNG screenshots
- [ ] The dataset is public and accessible without login or payment
- [ ] The dataset file is included, or `DATA.md` is included if the file is too large
- [ ] `README.md` includes the new results row and audit section
- [ ] A notebook was added if the audit benefits from one

**Before fairness gap:** <!-- e.g. 86.77% -->

**After fairness gap:** <!-- e.g. 15.69% -->

**Reduction:** <!-- e.g. 71% -->

**Protected attribute(s):** <!-- e.g. Race -->

**Proxy variables dropped:** <!-- e.g. CustodyStatus -->

---

## Explainer checklist

<!-- Skip this section if you're submitting an audit or bug fix -->

- [ ] The file is in `explainers/` and uses lowercase hyphenated naming
- [ ] It includes a plain-language definition
- [ ] It uses a real example from this repo or a documented real-world case
- [ ] It includes runnable Python detection or measurement code
- [ ] It acknowledges limitations or trade-offs
- [ ] It links to related explainers or repo projects
- [ ] It includes 2-3 primary sources
- [ ] The Explainers table in `README.md` was updated

---

## Linked issue

<!-- Every PR should have a corresponding issue. Example: "Closes #12" -->

Closes #
