### PR TITLE
fix: correct COMPAS dataset size on index.html (60k+, not 70k+)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2028,7 +2028,7 @@
       <div>
         <div class="project-num">PROJECT - 01</div>
         <h3 class="project-name">COMPAS</h3>
-        <p class="project-desc">A real algorithm used in US courtrooms. ProPublica's public dataset, 70,000+ records. The bias is not a glitch. It's baked in.</p>
+        <p class="project-desc">A real algorithm used in US courtrooms. ProPublica's public dataset, 60,000+ records. The bias is not a glitch. It's baked in.</p>
       </div>
       <div class="project-stats">
         <div class="stat-label">FAIRNESS GAP BEFORE</div>
@@ -2718,7 +2718,7 @@
       <div class="roadmap-status done"></div>
       <div>
         <div class="roadmap-name">COMPAS Criminal Justice</div>
-        <div class="roadmap-meta">ProPublica · 70k+ records · 71% bias reduction</div>
+        <div class="roadmap-meta">ProPublica · 60k+ records · 71% bias reduction</div>
       </div>
     </div>
     <div class="roadmap-item">


### PR DESCRIPTION
## Problem

`index.html`'s COMPAS cards claim "70,000+ records" / "70k+ records", but `COMPAS/compas-scores-raw.csv` has only **60,842 data rows** (`wc -l` = 60843 including the header). The filtered dataset the audit scripts actually use (`audit.yaml` `row_filters`: race in {African-American, Caucasian} and `DisplayText == "Risk of Recidivism"`) is ~16.3k rows, smaller still.

## Fix

Two spots updated to a figure that is accurate for the raw file shipped in the repo:

- Project card prose: `70,000+ records` -> `60,000+ records`
- Roadmap card meta: `70k+ records` -> `60k+ records`

`60,000+` is unambiguously true for the 60,842-row file (avoids implying >=61,000).

`python scripts/check_em_dash.py` passes.

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)