### PR TITLE
fix: show "N more groups" notice on the reference-baseline sub-table

### DIFF
--- a/faircode/report.py
+++ b/faircode/report.py
@@ -87,10 +87,13 @@ def to_terminal(result: dict) -> str:
         if meta:
             add(f"  ({'  '.join(meta)})")
         if d.get("reference"):
+            ref_groups = d["reference"]["groups"]
             add(f"  reference (deviation {d['reference']['deviation'] * 100:.1f}%):")
-            for g in d["reference"]["groups"][:DISPLAY_GROUPS]:
+            for g in ref_groups[:DISPLAY_GROUPS]:
                 add(f"    {g['label'][:16]:<16} exp {g['expected'] * 100:5.1f}%  "
                     f"act {g['actual'] * 100:5.1f}%  ({g['delta'] * 100:+5.1f} pp)")
+            if len(ref_groups) > DISPLAY_GROUPS:
+                add(f"    … and {len(ref_groups) - DISPLAY_GROUPS} more groups")
         add("")
 
     if result["flags"]:
@@ -224,13 +227,19 @@ def to_html(result: dict) -> str:
                 f'<td class="num">{g["delta"] * 100:+.1f} pp</td></tr>'
                 for g in ref["groups"][:DISPLAY_GROUPS]
             )
+            ref_more = ""
+            if len(ref["groups"]) > DISPLAY_GROUPS:
+                ref_more = (
+                    f'<div class="dim-more">… and '
+                    f'{len(ref["groups"]) - DISPLAY_GROUPS} more groups</div>'
+                )
             reference_html = (
                 f'<div class="reference"><h3>Reference '
                 f'<span class="kind">deviation {ref["deviation"] * 100:.1f}%</span></h3>'
                 f'<table><caption>Expected vs. actual share - {esc(d["name"])}</caption>'
                 f'<tr><th scope="col"></th><th scope="col" class="num">Expected</th>'
                 f'<th scope="col" class="num">Actual</th><th scope="col" class="num">Delta</th></tr>'
-                f'{ref_rows}</table></div>'
+                f'{ref_rows}</table>{ref_more}</div>'
             )
 
         meta_parts = []

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -145,6 +145,25 @@ def test_to_html_renders_reference_baseline_section(mock_profile_result):
     assert "-5.0 pp" in html_out
 
 
+def test_to_html_reports_reference_groups_omitted_by_display_cap(mock_profile_result):
+    """Mirrors test_to_html_reports_groups_omitted_by_display_cap for the
+    reference-baseline sub-table, which was silently truncated with no
+    dim-more notice."""
+    mock_profile_result["dimensions"][0]["reference"] = {
+        "deviation": 0.1,
+        "groups": [
+            {"label": f"Group {i}", "expected": 1 / 15, "actual": 1 / 15, "delta": 0.0}
+            for i in range(15)
+        ],
+    }
+
+    html_out = to_html(mock_profile_result)
+
+    assert "Group 11" in html_out
+    assert "Group 12" not in html_out
+    assert '<div class="dim-more">… and 3 more groups</div>' in html_out
+
+
 def test_to_html_omits_reference_section_when_absent(mock_profile_result):
     html_out = to_html(mock_profile_result)
 
@@ -266,6 +285,25 @@ def test_to_terminal_truncates_a_long_reference_group_label(mock_profile_result)
 
     assert ref_label[:16] in out
     assert ref_label not in out
+
+
+def test_to_terminal_reports_reference_groups_omitted_by_display_cap(mock_profile_result):
+    """SPEC section 7: every report surface that truncates a group list must
+    state how many groups were omitted. The reference sub-table used to be
+    silently capped at DISPLAY_GROUPS with no notice."""
+    mock_profile_result["dimensions"][0]["reference"] = {
+        "deviation": 0.1,
+        "groups": [
+            {"label": f"Group {i}", "expected": 1 / 15, "actual": 1 / 15, "delta": 0.0}
+            for i in range(15)
+        ],
+    }
+
+    out = to_terminal(mock_profile_result)
+
+    assert "Group 11" in out
+    assert "Group 12" not in out
+    assert "… and 3 more groups" in out
 
 
 def test_to_terminal_renders_flags_section(mock_profile_result):


### PR DESCRIPTION
## Problem

`faircode/SPEC.md` section 7: *"Whenever a dimension contains more groups [than `DISPLAY_GROUPS`], every report surface must state exactly how many groups were omitted."*

The main group breakdown honors this (`"… and N more groups"` in the terminal, a `dim-more` div in HTML). The **reference-baseline sub-table** right below it did not - `to_terminal` and `to_html`/`reference_html` both sliced `reference["groups"][:DISPLAY_GROUPS]` with no notice, so a reader saw the main table honestly say "8 more groups not shown" directly above a reference-comparison table that silently dropped the same 8.

## Fix

- `to_terminal`: after the reference row loop, emit `"    … and N more groups"` when `len(ref_groups) > DISPLAY_GROUPS` (indented to match the reference sub-table's rows).
- `to_html`: add a `<div class="dim-more">… and N more groups</div>` after the reference `<table>`, reusing the exact markup the main breakdown already uses.

No change when the reference has <= 12 groups.

### Verify (before/after)

```
$ python3 -m faircode profile geo.csv --reference geo_reference.csv   # 20 groups
... main breakdown:      … and 8 more groups
... reference (dev 4.0%): … and 8 more groups   # NEW
```

HTML now renders two `dim-more` divs (main + reference).

## Tests

- `test_to_terminal_reports_reference_groups_omitted_by_display_cap`
- `test_to_html_reports_reference_groups_omitted_by_display_cap`

Both mirror the existing main-table cap tests. `pytest tests/test_report.py` -> 28 passed. `ruff` clean.

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)