### PR TITLE
fix: get_benchmark_results rejects a filter on a column the chosen kind lacks

### DIFF
--- a/faircode/mcp_server.py
+++ b/faircode/mcp_server.py
@@ -301,10 +301,14 @@ def _get_explainer_impl(slug):
 def _get_benchmark_results_impl(kind="fairness", audit=None, model=None, strategy=None,
                                 metric=None, protected_attribute=None):
     """Filters the frozen benchmark CSV named by `kind` ("fairness" or
-    "performance") down to rows matching every given (non-None) filter,
-    ignoring a filter that names a column the chosen `kind` doesn't have
-    (e.g. `protected_attribute` against results_performance.csv, which has
-    no such column). Caps the returned rows at _RESULTS_ROW_LIMIT so an
+    "performance") down to rows matching every given (non-None) filter.
+    A filter that names a column the chosen `kind` doesn't have (e.g.
+    `protected_attribute` against results_performance.csv, which has no
+    such column) raises ValueError rather than being silently ignored, so
+    a caller can't get the whole unfiltered table back believing their
+    filter was applied - matching how profile_dataset/compare_datasets
+    reject an `overrides` column absent from the dataset. Caps the returned
+    rows at _RESULTS_ROW_LIMIT so an
     unfiltered or loosely-filtered call can't flood the calling agent's
     context - `total_matches`/`truncated` tell it whether to narrow the
     query. NaN cells (e.g. results_performance.csv's AUC rows have no
@@ -323,8 +327,13 @@ def _get_benchmark_results_impl(kind="fairness", audit=None, model=None, strateg
             continue
         if not isinstance(value, (str, int, float, bool)):
             raise ValueError(f"{column} must be a plain string, got {type(value).__name__}")
-        if column in df.columns:
-            df = df[df[column] == value]
+        if column not in df.columns:
+            raise ValueError(
+                f"{column!r} is not a column of the {kind!r} benchmark results "
+                f"(available: {', '.join(df.columns)}); it cannot be used as a "
+                f"filter for this kind"
+            )
+        df = df[df[column] == value]
     total = len(df)
     for column in _RESULTS_NUMERIC_COLUMNS:
         if column in df.columns:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -433,15 +433,22 @@ def test_get_benchmark_results_filters_to_matching_rows():
     assert row["significant"] is True
 
 
-def test_get_benchmark_results_performance_kind_ignores_protected_attribute_filter():
-    # results_performance.csv has no protected_attribute column - a filter
-    # naming it should be silently ignored, not raise or return zero rows.
-    result = _get_benchmark_results_impl(
-        kind="performance", audit="compas", model="logistic_regression",
-        protected_attribute="race")
+def test_get_benchmark_results_rejects_filter_on_column_absent_from_kind():
+    # results_performance.csv has no protected_attribute column. Silently
+    # dropping the filter handed the caller the whole unfiltered table back
+    # with no signal their filter was ignored (#512); it now raises, like
+    # profile_dataset/compare_datasets do for an unknown overrides column.
+    with pytest.raises(ValueError, match="protected_attribute.*performance"):
+        _get_benchmark_results_impl(
+            kind="performance", audit="compas", model="logistic_regression",
+            protected_attribute="race")
 
-    assert result["total_matches"] > 0
-    assert all(row["audit"] == "compas" for row in result["results"])
+    # The same filter against the fairness kind, which does have the column,
+    # still works.
+    ok = _get_benchmark_results_impl(
+        kind="fairness", audit="compas", model="logistic_regression",
+        protected_attribute="race")
+    assert ok["total_matches"] > 0
 
 
 def test_get_benchmark_results_nan_cells_become_none():


### PR DESCRIPTION
## Problem

`_get_benchmark_results_impl` (`faircode/mcp_server.py`) silently no-ops a filter whose column isn't in the selected `kind`'s CSV. `results_performance.csv` has no `protected_attribute` column, so:

```python
a = _get_benchmark_results_impl(kind="performance")
b = _get_benchmark_results_impl(kind="performance", protected_attribute="gender")
a["total_matches"], b["total_matches"], a == b
# -> 315 315 True
```

The caller asked for gender-specific performance numbers and got the whole unfiltered table back, with no way to tell from the response that the filter was dropped. A bogus *value* on a real column correctly returns `total_matches: 0`, so the tool already distinguishes "no match" from "filter applied" - just not "filter targets a column this kind doesn't have".

## Fix

Raise `ValueError` when a non-None filter names a column absent from the selected kind's CSV - the same contract `profile_dataset` / `compare_datasets` use for an `overrides` column that isn't in the dataset:

```
'protected_attribute' is not a column of the 'performance' benchmark results
(available: audit, strategy, model, metric, value, ci_low, ci_high, n);
it cannot be used as a filter for this kind
```

`audit`, `strategy`, `model`, `metric` exist in both frozen CSVs, so the only reachable case is `protected_attribute` vs `kind="performance"`. Docstring updated.

## Tests

`test_get_benchmark_results_performance_kind_ignores_protected_attribute_filter` (which asserted the silent-ignore behavior) is replaced by `test_get_benchmark_results_rejects_filter_on_column_absent_from_kind`, which checks the raise for `performance` and that the same filter still works against `fairness`.

`pytest tests/test_mcp_server.py` -> 57 passed, 1 failed. The failure (`test_get_explainer_returns_content_and_metadata`) is pre-existing on `main` on this platform (a `\` vs `/` path check in `_get_explainer_impl`) and unrelated to this change. `ruff` clean.

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)