### PR TITLE
fix: match profiler-engine.js NA tokens to pandas' STR_NA_VALUES exactly

### DIFF
--- a/assets/profiler-engine.js
+++ b/assets/profiler-engine.js
@@ -76,18 +76,21 @@
   var PSI_SIGNIFICANT = 0.25;
   var SCORE_DROP_FLAG = 5;
 
-  // Pandas-style missing tokens, so JS null-handling matches read_csv defaults.
+  // Pandas' default na_values (pandas.io.parsers.readers.STR_NA_VALUES),
+  // matched EXACTLY and case-sensitively so JS null-handling is bit-for-bit
+  // identical to loaders.py's plain pd.read_csv(). Notably: "None" IS in this
+  // set (pandas treats it as missing), while bare lowercase "na" and "none"
+  // are NOT - the previous list had both backwards, and lower-cased the cell
+  // before comparing, which also erased pandas' own case-sensitivity
+  // ("NA" is missing, "na" is not). See #491.
   var NA_TOKENS = {
-  '': 1,
-  'na': 1,
-  'n/a': 1,
-  'nan': 1,
-  'null': 1,
-  // Intentionally exclude "none" to match the Python profiler.
-  // In this project, pd.read_csv() preserves the literal string "none"
-  // as a categorical value, so treating it as missing breaks Python↔JS
-  // parity (see credit_customers.csv).
-};
+    '': 1,
+    '#N/A': 1, '#N/A N/A': 1, '#NA': 1,
+    '-1.#IND': 1, '-1.#QNAN': 1, '-NaN': 1, '-nan': 1,
+    '1.#IND': 1, '1.#QNAN': 1, '<NA>': 1,
+    'N/A': 1, 'NA': 1, 'NULL': 1, 'NaN': 1, 'None': 1,
+    'n/a': 1, 'nan': 1, 'null': 1,
+  };
 
   // ── Keyword lists - MUST mirror faircode/detect.py ─────────────────────
   var KEYWORDS = [
@@ -391,7 +394,8 @@
   }
   function isMissing(v) {
     if (v === null || v === undefined) return true;
-    return NA_TOKENS.hasOwnProperty(String(v).trim().toLowerCase());
+    // Case-sensitive, matching pandas' STR_NA_VALUES exactly (no lower-casing).
+    return NA_TOKENS.hasOwnProperty(String(v).trim());
   }
 
   // ── Column detection (SPEC section 1) ──────────────────────────────────

--- a/tests/test_js_parity.py
+++ b/tests/test_js_parity.py
@@ -195,6 +195,39 @@ def test_python_js_profiler_parity_rejects_negative_age_sentinels(tmp_path):
     assert age["missing_pct"] == 0.4
 
 
+def test_python_js_na_token_parity_on_literal_na_and_none(tmp_path):
+    """NA_TOKENS / isMissing() must match pandas' default STR_NA_VALUES
+    exactly and case-sensitively: literal "None" is missing, bare lowercase
+    "na" is a real category. The JS engine used to have both backwards and
+    lower-cased the cell before comparing (#491)."""
+    csv = tmp_path / "na_test.csv"
+    csv.write_text(
+        "status,x\n"
+        "active,1\ninactive,2\nna,3\nna,4\nNone,5\nNone,6\n"
+        "active,7\ninactive,8\nactive,9\ninactive,10\n",
+        encoding="utf-8",
+    )
+
+    python_result = profile(read_table(str(csv)))
+    completed = subprocess.run(
+        ["node", "scripts/engine-js.js", "profile", str(csv)],
+        capture_output=True, text=True, encoding="utf-8", check=True,
+    )
+    javascript_result = json.loads(completed.stdout)
+
+    python_result = dict(python_result)
+    javascript_result = dict(javascript_result)
+    python_result.pop("flags", None)
+    javascript_result.pop("flags", None)
+    assert javascript_result == python_result
+
+    status = next(d for d in python_result["dimensions"] if d["name"] == "status")
+    labels = {g["label"] for g in status["groups"]}
+    assert "na" in labels          # bare lowercase "na" is NOT a pandas NA token
+    assert "None" not in labels    # "None" IS a pandas NA token
+    assert status["missing_pct"] == 0.2
+
+
 def test_python_js_profiler_parity_with_overrides_cross_and_thresholds(tmp_path):
     """Non-default options - --map/--cross/--reference/thresholds - only ever
     had cross-engine parity coverage for their default-off path (issue #376).


### PR DESCRIPTION
## Problem

`assets/profiler-engine.js`'s `NA_TOKENS` / `isMissing()` disagreed with pandas' actual default `na_values` (`pandas.io.parsers.readers.STR_NA_VALUES`), which `faircode/loaders.py` gets by calling plain `pd.read_csv()`. Two things were backwards:

- `NA_TOKENS` **included** bare lowercase `"na"` - pandas does **not** treat that as missing
- `NA_TOKENS` **excluded** `"None"` - pandas **does** treat that as missing

and `isMissing()` did `String(v).trim().toLowerCase()` before the lookup, erasing pandas' case-sensitivity (`"NA"` is missing, `"na"` is not).

### Repro (before)

A `status` column with 2 literal `na` rows and 2 literal `None` rows out of 10:

```
python:  missing_pct 0.2, groups ['active', 'inactive', 'na']       # "None" missing, "na" kept
js:      missing_pct 0.2, groups ['active', 'None', 'inactive']     # exact opposite
```

Both report `0.2` for opposite reasons - parity is broken for any dataset using literal `"na"` or `"None"` text.

## Fix

`NA_TOKENS` now mirrors `STR_NA_VALUES` verbatim (`''`, `'#N/A'`, `'#N/A N/A'`, `'#NA'`, `'-1.#IND'`, `'-1.#QNAN'`, `'-NaN'`, `'-nan'`, `'1.#IND'`, `'1.#QNAN'`, `'<NA>'`, `'N/A'`, `'NA'`, `'NULL'`, `'NaN'`, `'None'`, `'n/a'`, `'nan'`, `'null'`) and `isMissing()` compares case-sensitively (drops `.toLowerCase()`).

### After

```
python:  missing_pct 0.2, groups ['active', 'inactive', 'na']
js:      missing_pct 0.2, groups ['active', 'inactive', 'na']
```

## Test

`test_python_js_na_token_parity_on_literal_na_and_none` - asserts byte-identical Python/JS structured output for a column with literal `na`/`None` cells, plus that `"na"` survives as a group and `"None"` counts as missing.

`pytest tests/test_js_parity.py` -> 22 passed, 1 failed. The failure (`test_python_js_profiler_parity_sniffs_quoted_newlines`) is pre-existing on `main` on this platform and unrelated - the 5 real-audit-dataset parity cases all still pass.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)