### PR TITLE
fix: web profiler export records resolved params, not sparse currentOpts

### DIFF
--- a/assets/profiler-compare.js
+++ b/assets/profiler-compare.js
@@ -653,7 +653,7 @@
       engine: 'js',
       dataset_hash_a: hashA.digest,
       dataset_hash_b: hashB.digest,
-      params: Object.assign({}, currentOpts),
+      params: E.publicParams(currentOpts),
       overrides: Object.assign({}, currentOverrides)
     };
     if (hashA.note !== null) provenance.dataset_hash_a_note = hashA.note;

--- a/assets/profiler-engine.js
+++ b/assets/profiler-engine.js
@@ -69,6 +69,25 @@
     validateOpts(o);
     return o;
   }
+
+  // Parsed data structures that carry their own provenance field elsewhere -
+  // echoing them into params would be noise. Mirrors
+  // faircode.provenance._OPAQUE_PARAMS.
+  var OPAQUE_PARAMS = { reference: 1 };
+
+  // The resolved knobs as actually applied (defaults included), minus the
+  // opaque parsed structures, key-sorted. Mirrors
+  // faircode.provenance.public_params(faircode.profiler._resolve_opts(opts)),
+  // so a web-profiler export's provenance.params matches the CLI/MCP path
+  // even when the user never touched a threshold input (#490).
+  function publicParams(opts) {
+    var resolved = resolveOpts(opts);
+    var out = {};
+    Object.keys(resolved).sort().forEach(function (k) {
+      if (!OPAQUE_PARAMS[k]) out[k] = resolved[k];
+    });
+    return out;
+  }
   // Comparison / drift (SPEC section 8)
   var PSI_EPSILON = 0.0001;
   var MISSING_DRIFT_FLAG = 0.05;
@@ -1088,6 +1107,9 @@
                               sniffDelimiter: sniffDelimiter,
                               profile: profile, compare: compare,
                               parseReference: parseReference,
+                              // publicParams: resolved knobs for an export's
+                              // provenance.params, matching the Python path (#490).
+                              publicParams: publicParams,
                               // Exposed so the Profile/Compare threshold-input
                               // placeholders (issue #377) can be sourced from
                               // this single source of truth instead of a

--- a/assets/profiler-ui.js
+++ b/assets/profiler-ui.js
@@ -752,7 +752,7 @@
       faircode_version: FAIRCODE_VERSION,
       engine: 'js',
       dataset_hash: hash.digest,
-      params: Object.assign({}, currentOpts),
+      params: E.publicParams(currentOpts),
       overrides: Object.assign({}, currentOverrides)
     };
 

--- a/tests/test_js_parity.py
+++ b/tests/test_js_parity.py
@@ -248,6 +248,31 @@ def test_python_js_na_token_parity_on_literal_na_and_none(tmp_path):
     assert status["missing_pct"] == 0.2
 
 
+def test_python_js_public_params_parity_for_a_defaulted_run():
+    """A web-profiler export with no threshold ever touched must still record
+    the 7 resolved defaults in provenance.params, matching the CLI/MCP path -
+    E.publicParams({}) mirrors provenance.public_params(_resolve_opts(None)) (#490)."""
+    from faircode.profiler import _resolve_opts
+    from faircode.provenance import public_params
+
+    expected = public_params(_resolve_opts(None))
+
+    script = (
+        "require(process.argv[1]);"
+        "process.stdout.write(JSON.stringify(globalThis.FairCodeProfiler.publicParams({})));"
+    )
+    completed = subprocess.run(
+        ["node", "-e", script, str(REPO_ROOT / "assets" / "profiler-engine.js")],
+        capture_output=True, text=True, encoding="utf-8", check=True,
+    )
+    assert json.loads(completed.stdout) == expected
+    assert set(expected) == {
+        "cross", "imbalance_flag", "intersection_floor", "min_group_size",
+        "min_share", "missing_flag", "reference_flag",
+    }
+    assert "reference" not in expected
+
+
 def test_python_js_profiler_parity_with_overrides_cross_and_thresholds(tmp_path):
     """Non-default options - --map/--cross/--reference/thresholds - only ever
     had cross-engine parity coverage for their default-off path (issue #376).


### PR DESCRIPTION
## Problem

`assets/profiler-ui.js` and `assets/profiler-compare.js` both build the export's provenance as:

```js
params: Object.assign({}, currentOpts),
```

`currentOpts` starts as `{}` on every upload and only gains a key when the user manually edits a threshold input. So for any plain run where no threshold is touched (the common case), `provenance.params` is exported as `{}` - not the 7 resolved defaults that `SPEC.md` section 10 requires ("the knobs of section 7 as resolved, defaults included") and that the Python CLI/MCP path already records via `provenance.public_params`.

```
python: {'cross': None, 'imbalance_flag': 3.0, 'intersection_floor': 0.01,
         'min_group_size': 100, 'min_share': 0.05, 'missing_flag': 0.05,
         'reference_flag': 0.05}
js:     {}
```

An export that omits every default threshold can't answer "was this produced from these thresholds" after the fact.

## Fix

New `E.publicParams(opts)` in `profiler-engine.js`, mirroring `faircode.provenance.public_params(faircode.profiler._resolve_opts(opts))`:

```js
function publicParams(opts) {
  var resolved = resolveOpts(opts);          // merge over DEFAULT_OPTS
  var out = {};
  Object.keys(resolved).sort().forEach(function (k) {
    if (!OPAQUE_PARAMS[k]) out[k] = resolved[k];   // drop the parsed `reference` object
  });
  return out;
}
```

Exported from the engine, and used at both `params:` sites. A user-set threshold still shows through (`publicParams({min_share: 0.2})` -> `min_share: 0.2`, rest defaulted).

## Test

`test_python_js_public_params_parity_for_a_defaulted_run` - asserts `E.publicParams({})` (run under Node) equals `public_params(_resolve_opts(None))` and carries exactly the 7 expected keys, `reference` not among them.

`pytest tests/test_js_parity.py` -> 22 passed, 1 failed (`test_python_js_profiler_parity_sniffs_quoted_newlines`, pre-existing on `main` on this platform, unrelated).

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)