### PR TITLE
fix: compare cards show "comparison skipped" for a kind mismatch, not "none drift"

### DIFF
--- a/assets/profiler-compare.js
+++ b/assets/profiler-compare.js
@@ -383,7 +383,28 @@
       '<span class="l">' + esc(side.name) + '</span></div>';
   }
 
+  // A dimension auto-detected to different kinds on each side (or age-banded
+  // on only one side) has its drift comparison skipped by the engine, which
+  // leaves psi/tvd/drift_level at 0/0/'none'. Rendering that as a "none drift"
+  // badge asserts a measurement that never happened - often right next to a
+  // real score change. Show a "comparison skipped" card instead (#519).
+  function kindMismatchReason(cd) {
+    return cd.kind_a !== cd.kind_b
+      ? 'detected as ' + esc(cd.kind_a) + ' vs ' + esc(cd.kind_b) +
+        ' on the two datasets'
+      : 'age values banded on one dataset, raw on the other';
+  }
+
   function driftCard(cd) {
+    if (cd.kind_mismatch) {
+      return '<div class="drift-card"><div class="drift-card-head"><div>' +
+        '<span class="dim-name">' + esc(cd.name) + '</span>' +
+        '<span class="dim-kind">' + esc(cd.kind_a) + ' / ' + esc(cd.kind_b) + '</span>' +
+        '<span class="drift-badge skipped">comparison skipped</span>' +
+        '</div><span class="drift-metrics">' + kindMismatchReason(cd) +
+        ' · score ' + cd.dimension_score_a + '→' + cd.dimension_score_b +
+        ' (' + signed(cd.dimension_score_delta, 0) + ')</span></div></div>';
+    }
     var head = '<div class="drift-card-head"><div>' +
       '<span class="dim-name">' + esc(cd.name) + '</span>' +
       '<span class="dim-kind">' + esc(cd.kind) + '</span>' +
@@ -459,6 +480,17 @@
       cardsHtml = '<p class="section-note">No demographic dimension is present in both datasets to compare.</p>';
     } else {
       cardsHtml = cmp.dimensions.map(function (cd) {
+        if (cd.kind_mismatch) {
+          return '<section class="drift-card"><div class="drift-card-head">' +
+            '<h2>' + esc(cd.name) + ' <span class="kind">' + esc(cd.kind_a) +
+            ' / ' + esc(cd.kind_b) + '</span> ' +
+            '<span class="drift-badge skipped">comparison skipped</span></h2>' +
+            '<div class="drift-metrics">' + kindMismatchReason(cd) +
+            ' · score ' + cd.dimension_score_a + '→' + cd.dimension_score_b +
+            ' (' + signed(cd.dimension_score_delta, 0) + ')</div></div>' +
+            '<p class="section-note">Drift metrics are not computed when a ' +
+            'dimension is detected as a different kind on each side.</p></section>';
+        }
         var maxShare = 0;
         cd.groups.forEach(function (g) { maxShare = Math.max(maxShare, g.share_a, g.share_b); });
         if (maxShare <= 0) maxShare = 1;
@@ -532,6 +564,7 @@
       '.drift-badge.none { background:var(--accent3); color:#fff; } ' +
       '.drift-badge.moderate { background:var(--warn); color:#fff; } ' +
       '.drift-badge.significant { background:var(--accent); color:#fff; } ' +
+      '.drift-badge.skipped { background:var(--muted); color:#fff; } ' +
       '.drift-card { background:var(--surface); border:1px solid var(--border); border-radius:8px; padding:16px 20px; margin:16px 0; } ' +
       '.drift-card-head { display:flex; justify-content:space-between; align-items:baseline; border-bottom:1px solid var(--border); padding-bottom:8px; margin-bottom:12px; } ' +
       '.drift-card-head h2 { margin:0; font-size:18px; } ' +

--- a/assets/profiler.css
+++ b/assets/profiler.css
@@ -387,6 +387,7 @@
 .drift-badge.none { color: var(--accent3); border: 1px solid var(--accent3); }
 .drift-badge.moderate { color: var(--warn); border: 1px solid var(--warn); }
 .drift-badge.significant { color: var(--accent); border: 1px solid var(--accent); }
+.drift-badge.skipped { color: var(--muted); border: 1px solid var(--muted); }
 .drift-metrics { font-family: var(--mono); font-size: 12px; color: var(--muted); }
 
 .drift-row {

--- a/tests/test_js_parity.py
+++ b/tests/test_js_parity.py
@@ -37,6 +37,26 @@ def test_sheetjs_cdn_url_matches():
     assert engine_url == cli_url
 
 
+def test_compare_card_renderers_special_case_kind_mismatch():
+    """driftCard() and buildCompareHtmlReport()'s per-dimension section must
+    both read cd.kind_mismatch, so a skipped comparison isn't drawn as a
+    "none drift" badge next to a real score change (#519). Source-level check
+    (mirrors test_sheetjs_cdn_url_matches) - these renderers are DOM-coupled
+    and have no unit harness."""
+    src = (REPO_ROOT / "assets" / "profiler-compare.js").read_text(encoding="utf-8")
+
+    drift_card = src[src.index("function driftCard("):]
+    drift_card = drift_card[: drift_card.index("\n  }\n")]
+    assert "kind_mismatch" in drift_card
+    assert "comparison skipped" in drift_card
+
+    report = src[src.index("function buildCompareHtmlReport("):]
+    assert "if (cd.kind_mismatch)" in report
+    # the skipped badge is styled in both the live css and the report's own <style>
+    assert ".drift-badge.skipped" in src
+    assert ".drift-badge.skipped" in (REPO_ROOT / "assets" / "profiler.css").read_text(encoding="utf-8")
+
+
 # Real audit datasets are already tracked in their own audit folders - reuse
 # them instead of keeping a second multi-megabyte copy under tests/fixtures.
 CSV_PATHS = {


### PR DESCRIPTION
## Problem

When a dimension is auto-detected to different kinds on each side (`kind_mismatch`, e.g. `geography` in dataset A, `categorical` in B), the engine deliberately **skips** the drift comparison and returns `psi: 0, tvd: 0, drift_level: 'none', groups: []`. But `assets/profiler-compare.js`'s `driftCard()` and `buildCompareHtmlReport()`'s per-dimension section never read `cd.kind_mismatch`, so the card renders:

> **region** geography · `NONE DRIFT` · PSI 0.000 · TVD 0.000 · score 80→60 (-20)

A card that visually asserts "none drift" for a comparison that was never measured, next to a genuine -20 score change. The real reason is only in the separate Drift Flags list. (The CLI / `--fail-on-drift` version of this was already fixed; this is the browser UI, live view + downloadable HTML report.)

## Fix

Both renderers now special-case `cd.kind_mismatch`:

- a muted **`comparison skipped`** badge instead of `none drift`
- the reason inline: `detected as geography vs categorical on the two datasets`, or `age values banded on one dataset, raw on the other`
- the real `score A→B (delta)` is kept
- the PSI/TVD line and the group table are dropped (there are no meaningful values)

New `.drift-badge.skipped` rule in `assets/profiler.css` and in the HTML report's own inline `<style>`.

## Test

`test_compare_card_renderers_special_case_kind_mismatch` - source-level check (mirrors the existing `test_sheetjs_cdn_url_matches` pattern; these renderers are DOM-coupled and have no unit harness) that both `driftCard()` and `buildCompareHtmlReport()` read `cd.kind_mismatch` and that the badge is styled in both stylesheets. Engine already emits `kind_mismatch: true` with the `kind_a` / `kind_b` / `dimension_score_*` fields the new code reads. `node -c` clean; `test_python_js_compare_parity` still passes.

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)