### PR TITLE
fix: keep non-numeric age sentinels as labels in the intersection crosstab

### DIFF
--- a/assets/profiler-engine.js
+++ b/assets/profiler-engine.js
@@ -670,7 +670,16 @@
         if (ageToNumeric(rows[i][name]) !== null) { any = true; break; }
       }
       if (any) {
-        for (i = 0; i < rows.length; i++) out.push(ageBand(ageToNumeric(rows[i][name])));
+        for (i = 0; i < rows.length; i++) {
+          var value = rows[i][name];
+          var num = ageToNumeric(value);
+          // Non-numeric age sentinels get their own categorical label here
+          // too, matching dimension()'s main breakdown - otherwise they map
+          // to null and intersections() drops those rows, so the crosstab
+          // and the main groups disagree (#524).
+          out.push(num !== null ? ageBand(num)
+                   : (isCategoricalAgeSentinel(value) ? String(value) : null));
+        }
         return out;
       }
     }

--- a/faircode/profiler.py
+++ b/faircode/profiler.py
@@ -298,7 +298,17 @@ def _intersections(df: pd.DataFrame, dims: list[dict],
         if kind == "age" and not _looks_like_dates(df[name]):
             nums = [_age_to_numeric(v) for v in df[name]]
             if any(n is not None for n in nums):
-                return pd.Series([_age_band(n) for n in nums], index=df.index)
+                # Non-numeric age sentinels ("unknown", "prefer not to say")
+                # get their own categorical label here too, matching
+                # _dimension()'s main breakdown - otherwise labelize() maps
+                # them to None and pd.crosstab silently drops those rows, so
+                # the intersection view and the main groups disagree (#524).
+                labels = [
+                    _age_band(num) if num is not None
+                    else (str(value) if _is_categorical_age_sentinel(value) else None)
+                    for value, num in zip(df[name], nums)
+                ]
+                return pd.Series(labels, index=df.index)
         return df[name].astype("object")
 
     sa = labelize(a["name"], a["kind"])

--- a/tests/test_js_parity.py
+++ b/tests/test_js_parity.py
@@ -253,6 +253,39 @@ def test_python_js_reject_out_of_range_min_share_parity(tmp_path):
     assert "min_share must be between 0 and 1" in completed.stderr
 
 
+def test_python_js_intersection_parity_keeps_non_numeric_age_sentinels(tmp_path):
+    """labelize() gives a non-numeric age sentinel its own crosstab label on
+    both engines, instead of mapping it to null and dropping the row (#524)."""
+    csv = tmp_path / "age_sentinels.csv"
+    ages = ["25", "30", "45", "unknown", "unknown", "unknown",
+            "prefer not to say", "22", "33", "41"] * 3
+    sexes = ["M", "F"] * 15
+    csv.write_text(
+        "age,sex\n" + "\n".join(a + "," + s for a, s in zip(ages, sexes)) + "\n",
+        encoding="utf-8",
+    )
+
+    opts = {"cross": ["age", "sex"]}
+    python_result = profile(pd.read_csv(csv, dtype={"age": str}), opts=opts)
+
+    opts_path = tmp_path / "opts.json"
+    opts_path.write_text(json.dumps({"opts": opts}), encoding="utf-8")
+    completed = subprocess.run(
+        ["node", "scripts/engine-js.js", "profile", str(csv), str(opts_path)],
+        capture_output=True, text=True, encoding="utf-8", check=True,
+    )
+    javascript_result = json.loads(completed.stdout)
+
+    python_result = dict(python_result)
+    javascript_result = dict(javascript_result)
+    python_result.pop("flags", None)
+    javascript_result.pop("flags", None)
+    assert javascript_result == python_result
+
+    a_labels = {c["a"] for c in python_result["intersections"][0]["cells"]}
+    assert "prefer not to say" in a_labels
+
+
 def test_python_js_cross_parity_on_unmatched_column(tmp_path):
     """An unmatched `cross` column raises the same error on both engines
     instead of the JS engine silently falling back to the first two detected

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -429,6 +429,45 @@ def test_intersections_labelize_respects_date_guard():
     }
 
 
+def test_intersections_labelize_keeps_non_numeric_age_sentinels():
+    # #524: _dimension()'s main breakdown gives "unknown"/"prefer not to say"
+    # their own categorical group, but _intersections()'s labelize() used to
+    # map them to None, so pd.crosstab dropped those rows entirely - the
+    # crosstab and the main groups then disagreed about the same dataset.
+    df = pd.DataFrame({
+        "age": [25, 30, 45, "unknown", "unknown", "unknown",
+                "prefer not to say", 22, 33, 41] * 3,
+        "sex": ["M", "F"] * 15,
+    })
+
+    result = profile(df, opts={"cross": ["age", "sex"]})
+
+    age_dim = next(d for d in result["dimensions"] if d["name"] == "age")
+    main_labels = {g["label"] for g in age_dim["groups"]}
+    assert {"unknown", "prefer not to say"} <= main_labels
+
+    crosstab_a_labels = {c["a"] for c in result["intersections"][0]["cells"]}
+    # a genuinely-missing (NaN) age cell would still be absent here, but a
+    # present sentinel value must now appear as its own crosstab row
+    assert "prefer not to say" in crosstab_a_labels
+
+
+def test_intersections_labelize_still_drops_genuinely_missing_age_cells():
+    # The flip side: a real blank / range-invalid age cell must still be
+    # absent from the crosstab (mapped to None), not turned into a group.
+    df = pd.DataFrame({
+        "age": [25, 30, 45, None, float("nan"), -1, 22, 33, 41, 29] * 3,
+        "sex": ["M", "F"] * 15,
+    })
+
+    result = profile(df, opts={"cross": ["age", "sex"]})
+
+    crosstab_a_labels = {c["a"] for c in result["intersections"][0]["cells"]}
+    assert "nan" not in crosstab_a_labels
+    assert "-1" not in crosstab_a_labels
+    assert "None" not in crosstab_a_labels
+
+
 def test_date_column_dropped_not_garbage():
     # A birthdate column must not become 6 nonsense age bands.
     df = pd.DataFrame({


### PR DESCRIPTION
## Problem

#487 / #509 gave non-numeric age sentinels (`"unknown"`, `"prefer not to say"`) their own categorical group in `profile()`'s main per-dimension breakdown. `_intersections()`'s `labelize()` helper - a separate code path, explicitly called out as a deferred follow-up in that fix's commit message - still routed them through `_age_band()` -> `None`, and `pd.crosstab()` drops NaN rows by default. So those rows vanished from the intersectional crosstab entirely.

### Repro (before)

```
profile() age groups: [('18-30', 6), ('30-45', 9), ('45-60', 3), ('prefer not to say', 3), ('unknown', 9)]
intersections:        [{'dims': ['age', 'sex'], 'cells': [{'a': '45-60', 'b': 'F', 'count': 0}]}]
```

12 of 30 rows are real groups in the main breakdown but invisible to the intersection view - not even shown as an "unknown" cell.

## Fix

`labelize()` (Python) and its mirror in `assets/profiler-engine.js` now apply the same `_is_categorical_age_sentinel()` handling that `_dimension()` already uses:

- a **present** non-numeric sentinel -> its literal string value as the crosstab label
- a genuinely **missing** (`None`/`NaN`) or **range-invalid** (`-1`) cell -> still `None`, still dropped (unchanged)

### After

```
intersections: [{'dims': ['age', 'sex'], 'cells': [
  {'a': '45-60', 'b': 'F', 'count': 0},
  {'a': 'prefer not to say', 'b': 'F', 'count': 0}]}]
```

## Tests

- `test_intersections_labelize_keeps_non_numeric_age_sentinels` (`test_profiler.py`)
- `test_intersections_labelize_still_drops_genuinely_missing_age_cells` (the flip side)
- `test_python_js_intersection_parity_keeps_non_numeric_age_sentinels` (`test_js_parity.py`) - byte-identical Python/JS crosstab

`pytest tests/test_profiler.py tests/test_js_parity.py` -> 59 passed, 1 failed (`test_python_js_profiler_parity_sniffs_quoted_newlines`, pre-existing on `main` on this platform, unrelated). `ruff` clean.

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)