### PR TITLE
fix: figures.py renders one bar per protected attribute for multi-PA audits

### DIFF
--- a/faircode/figures.py
+++ b/faircode/figures.py
@@ -22,24 +22,58 @@ from .strategies import STRATEGIES
 FIGURE_DPI = 300
 
 
+_BAR_COLORS = ("#4C72B0", "#DD8452", "#55A868", "#C44E52", "#8172B2", "#937860")
+
+
 def plot_strategy_comparison(fairness_df: pd.DataFrame, audit: str, out_path,
                              metric: str = "demographic_parity_diff"):
     """Bar chart of `metric`'s point estimate across the five mitigation
-    strategies (averaged across model families) for one audit."""
+    strategies (averaged across model families) for one audit.
+
+    For an audit that declares more than one protected attribute, the value
+    is broken out into one bar per protected attribute within each strategy
+    group, rather than averaged into a single bar - averaging across
+    different protected attributes blends genuinely different (often
+    oppositely-signed) fairness gaps into one number that represents none of
+    them (#525). A single-attribute audit renders one bar per strategy as
+    before.
+    """
     import matplotlib
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
+    import numpy as np
 
     subset = fairness_df[(fairness_df["audit"] == audit) & (fairness_df["metric"] == metric)]
     if subset.empty:
         raise ValueError(f"no rows for audit={audit!r} metric={metric!r}")
 
-    grouped = subset.groupby("strategy")["value"].mean().reindex(STRATEGIES)
+    has_pa = "protected_attribute" in subset.columns
+    attrs = sorted(subset["protected_attribute"].dropna().unique()) if has_pa else []
+
     fig, ax = plt.subplots(figsize=(8, 4.5))
-    ax.bar(grouped.index, grouped.to_numpy(), color="#4C72B0")
+
+    if len(attrs) > 1:
+        x = np.arange(len(STRATEGIES))
+        width = 0.8 / len(attrs)
+        for i, attr in enumerate(attrs):
+            per_strategy = (subset[subset["protected_attribute"] == attr]
+                            .groupby("strategy")["value"].mean().reindex(STRATEGIES))
+            offset = (i - (len(attrs) - 1) / 2) * width
+            ax.bar(x + offset, per_strategy.to_numpy(), width,
+                   label=str(attr), color=_BAR_COLORS[i % len(_BAR_COLORS)])
+        ax.set_xticks(x)
+        ax.set_xticklabels(STRATEGIES)
+        ax.legend(title="protected attribute")
+        title = (f"{audit}: {metric.replace('_', ' ')} by protected attribute "
+                 f"across mitigation strategies")
+    else:
+        grouped = subset.groupby("strategy")["value"].mean().reindex(STRATEGIES)
+        ax.bar(grouped.index, grouped.to_numpy(), color=_BAR_COLORS[0])
+        title = f"{audit}: {metric.replace('_', ' ')} across mitigation strategies"
+
     ax.axhline(0, color="black", linewidth=0.8)
     ax.set_ylabel(metric.replace("_", " "))
-    ax.set_title(f"{audit}: {metric.replace('_', ' ')} across mitigation strategies")
+    ax.set_title(title)
     ax.tick_params(axis="x", rotation=20)
     fig.tight_layout()
     fig.savefig(out_path, dpi=FIGURE_DPI)

--- a/tests/test_figures.py
+++ b/tests/test_figures.py
@@ -38,6 +38,42 @@ def test_plot_strategy_comparison_writes_a_png(tmp_path):
     assert out_path.stat().st_size > 0
 
 
+def _multi_pa_fairness_df(metric="demographic_parity_diff", audit="toy_audit"):
+    rows = []
+    for strategy in STRATEGIES:
+        for model in ("logistic_regression", "random_forest", "gradient_boosting"):
+            for pa, value in (("age", 0.04), ("sex", -0.15)):
+                rows.append({
+                    "audit": audit, "strategy": strategy, "model": model,
+                    "protected_attribute": pa, "metric": metric, "value": value,
+                })
+    return pd.DataFrame(rows)
+
+
+def test_plot_strategy_comparison_grouped_bars_for_multi_attribute_audit(tmp_path):
+    # A multi-protected-attribute audit must not average age's +0.04 and
+    # sex's -0.15 into one meaningless -0.05 bar (#525) - it renders one bar
+    # per protected attribute per strategy instead.
+    df = _multi_pa_fairness_df()
+    out_path = tmp_path / "toy_audit_strategies.png"
+
+    plot_strategy_comparison(df, "toy_audit", out_path)
+
+    assert out_path.is_file() and out_path.stat().st_size > 0
+
+
+def test_plot_strategy_comparison_single_attribute_still_one_series(tmp_path):
+    # A protected_attribute column with only one distinct value keeps the
+    # original one-bar-per-strategy rendering.
+    df = _multi_pa_fairness_df()
+    df = df[df["protected_attribute"] == "age"]
+    out_path = tmp_path / "toy_audit_strategies.png"
+
+    plot_strategy_comparison(df, "toy_audit", out_path)
+
+    assert out_path.is_file() and out_path.stat().st_size > 0
+
+
 def test_generate_figures_writes_one_png_per_audit(tmp_path):
     results_dir = tmp_path / "results"
     results_dir.mkdir()


### PR DESCRIPTION
## Problem

`faircode/figures.py`'s `plot_strategy_comparison` does:

```python
grouped = subset.groupby("strategy")["value"].mean().reindex(STRATEGIES)
```

`subset` is filtered only by `audit` and `metric`, so for an audit that declares more than one protected attribute it contains rows for **every** protected attribute at once. Grouping by `strategy` alone averages the metric *across different protected attributes* into one bar.

For `benefits_denial` baseline (`demographic_parity_diff`):

```
protected_attribute
age                0.041068
national_origin    0.032570
race              -0.086943
sex               -0.154586
figures.py's blended bar: -0.041973
```

Genuinely different, oppositely-signed gaps -> one bar that matches none of them and specifically washes out the largest (sex). The chart names only the audit and metric, so a reader can't tell this blending happened. Three of the seven audits (Insurance Denial, Benefits Denial, Healthcare Readmission) declare 2-4 protected attributes.

## Fix

When the subset has more than one `protected_attribute`, render a **grouped bar chart**: one bar per protected attribute within each strategy group, with a legend. A single-attribute audit - or any results file with no `protected_attribute` column - renders one bar per strategy exactly as before.

Verified against `paper/results-frozen/results_fairness.csv`: `benefits_denial` -> 4-series grouped chart, `compas` -> unchanged single-series chart.

## Tests

- `test_plot_strategy_comparison_grouped_bars_for_multi_attribute_audit`
- `test_plot_strategy_comparison_single_attribute_still_one_series`

`pytest tests/test_figures.py` -> 7 passed. `ruff` clean.

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)