### PR TITLE
chore: regenerate explainer output left stale by #(Benefits Denial audit number fix)

### DIFF
--- a/explainers/unsupervised-learning.html
+++ b/explainers/unsupervised-learning.html
@@ -112,7 +112,7 @@
         "url": "https://www.thefaircode.xyz/index.html#explainers"
       },
       "datePublished": "2026-07-14",
-      "dateModified": "2026-07-14"
+      "dateModified": "2026-09-09"
     },
     {
       "@type": "FAQPage",
@@ -212,7 +212,7 @@ Xs = StandardScaler().fit_transform(X)
 km = KMeans(n_clusters=2, random_state=42, n_init=10)
 df[&#x27;cluster&#x27;] = km.fit_predict(Xs)</code></pre>
 <p><code>sex</code>, <code>race</code>, and <code>native.country</code> never appear in <code>feature_cols</code>. The clustering step has no way to &quot;see&quot; them. Whatever split it produces has to come entirely from the other nine columns.</p>
-<h3 id="concrete-example-benefits-denial-audit-04">Concrete Example: Benefits Denial - Audit 04</h3>
+<h3 id="concrete-example-benefits-denial-audit-05">Concrete Example: Benefits Denial - Audit 05</h3>
 <p>Running the code above on the UCI Adult Census Income dataset (32,561 records, the same file the Benefits Denial audit trains on) produces two clusters of size 17,680 and 14,881. Neither <code>sex</code>, <code>race</code>, nor <code>native.country</code> was part of the clustering input, so the composition of each cluster along those attributes was checked after the fact, not fed in beforehand:</p>
 <div class="explainer-table-wrap"><table class="explainer-table"><thead><tr><th></th><th>Cluster 0 (n=17,680)</th><th>Cluster 1 (n=14,881)</th></tr></thead><tbody><tr><td>Female</td><td>51.9%</td><td>10.7%</td></tr><tr><td>Male</td><td>48.1%</td><td>89.3%</td></tr><tr><td>Black</td><td>13.0%</td><td>5.6%</td></tr><tr><td>White</td><td>81.9%</td><td>89.6%</td></tr><tr><td>Foreign-born</td><td>10.2%</td><td>10.7%</td></tr></tbody></table></div>
 <p>Cluster 1 is 89.3% male against cluster 0&#x27;s near-even split, and Black applicants appear at more than double the rate in cluster 0 versus cluster 1. Nobody asked the algorithm to separate applicants by sex or race. It separated them by <code>relationship</code>, <code>marital.status</code>, <code>occupation</code>, and <code>hours.per.week</code>, and a sex and race split came out the other side as a side effect, exactly the mechanism <a href="proxy-variables.html">What Is a Proxy Variable?</a> describes for supervised models, now showing up with no label in sight.</p>

--- a/faircode/_explainers/unsupervised-learning.md
+++ b/faircode/_explainers/unsupervised-learning.md
@@ -36,7 +36,7 @@ df['cluster'] = km.fit_predict(Xs)
 
 `sex`, `race`, and `native.country` never appear in `feature_cols`. The clustering step has no way to "see" them. Whatever split it produces has to come entirely from the other nine columns.
 
-## Concrete Example: Benefits Denial - Audit 04
+## Concrete Example: Benefits Denial - Audit 05
 
 Running the code above on the UCI Adult Census Income dataset (32,561 records, the same file the Benefits Denial audit trains on) produces two clusters of size 17,680 and 14,881. Neither `sex`, `race`, nor `native.country` was part of the clustering input, so the composition of each cluster along those attributes was checked after the fact, not fed in beforehand:
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6521,7 +6521,7 @@ df['cluster'] = km.fit_predict(Xs)
 
 `sex`, `race`, and `native.country` never appear in `feature_cols`. The clustering step has no way to "see" them. Whatever split it produces has to come entirely from the other nine columns.
 
-## Concrete Example: Benefits Denial - Audit 04
+## Concrete Example: Benefits Denial - Audit 05
 
 Running the code above on the UCI Adult Census Income dataset (32,561 records, the same file the Benefits Denial audit trains on) produces two clusters of size 17,680 and 14,881. Neither `sex`, `race`, nor `native.country` was part of the clustering input, so the composition of each cluster along those attributes was checked after the fact, not fed in beforehand:
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.thefaircode.xyz/</loc>
-    <lastmod>2026-09-08</lastmod>
+    <lastmod>2026-09-09</lastmod>
   </url>
   <url>
     <loc>https://www.thefaircode.xyz/profiler.html</loc>
@@ -114,7 +114,7 @@
   </url>
   <url>
     <loc>https://www.thefaircode.xyz/explainers/unsupervised-learning.html</loc>
-    <lastmod>2026-07-14</lastmod>
+    <lastmod>2026-09-09</lastmod>
   </url>
   <url>
     <loc>https://www.thefaircode.xyz/explainers/model-drift.html</loc>


### PR DESCRIPTION
## Problem

`main` currently fails the `build-explainers` CI job (`scripts/check_generated_files_current.py`):

```
Generated files are out of date - run 'make build-explainers' locally and commit the result.
  explainers/unsupervised-learning.html: content differs from a fresh regeneration
  llms-full.txt: content differs from a fresh regeneration
  faircode/_explainers/unsupervised-learning.md: content differs from a fresh regeneration
```

Commit `c898369` ("docs: correct Benefits Denial audit number") edited `explainers/unsupervised-learning.md` - the "Concrete Example: Benefits Denial - Audit 04" heading became "Audit 05" - but the generated pages were not rebuilt, so the `.html`, its package mirror, `llms-full.txt`, and `sitemap.xml` still carry the old heading/anchor (and stale `dateModified`).

## Fix

Ran `python scripts/build_explainers.py` and committed **only** its output diff (4 files, 6 lines): the `Audit 04` -> `Audit 05` heading + anchor in the generated page, and the `dateModified` bump. `check_generated_files_current.py` passes again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)