### PR TITLE
docs: fix fabricated ~20.9pp hiring gap in three explainers

### DIFF
--- a/explainers/demographic-parity.html
+++ b/explainers/demographic-parity.html
@@ -211,11 +211,10 @@
 <h3 id="real-world-proof-hiring-bias">Real-World Proof: Hiring Bias</h3>
 <p>The AI Fair Recruitment audit in this repo is a direct illustration of a demographic parity violation - and its fix.</p>
 <p>A model trained with gender and age as features assigned hire recommendations at sharply different rates:</p>
-<div class="explainer-table-wrap"><table class="explainer-table"><thead><tr><th>Group</th><th>Hire Rate</th></tr></thead><tbody><tr><td>Male applicants</td><td>~71%</td></tr><tr><td>Female applicants</td><td>~50%</td></tr><tr><td><strong>Fairness Gap</strong></td><td><strong>~20.9 percentage points</strong></td></tr></tbody></table></div>
+<div class="explainer-table-wrap"><table class="explainer-table"><thead><tr><th>Group</th><th>Hire Rate</th></tr></thead><tbody><tr><td>Male applicants</td><td>21.62%</td></tr><tr><td>Female applicants</td><td>17.10%</td></tr><tr><td><strong>Fairness Gap</strong></td><td><strong>4.51 percentage points</strong></td></tr></tbody></table></div>
+<p>(The disparate-impact ratio here is 17.10 / 21.62 = 0.79, below the 0.80 four-fifths threshold.)</p>
 <p>The model was not told to discriminate. It learned to - by treating age as a proxy for gender, because women in the dataset more often had career gaps. Age was correlated with gender, so including it smuggled the gender signal back in even without an explicit gender rule.</p>
-<p>After dropping gender and age (the protected attribute and its proxy):</p>
-<div class="explainer-table-wrap"><table class="explainer-table"><thead><tr><th>Group</th><th>Hire Rate</th></tr></thead><tbody><tr><td>Male applicants</td><td>~67%</td></tr><tr><td>Female applicants</td><td>~67%</td></tr><tr><td><strong>New Fairness Gap</strong></td><td><strong>~0.12 percentage points</strong></td></tr></tbody></table></div>
-<p><strong>97.3% reduction.</strong> The gap wasn&#x27;t in the underlying merit of candidates - it was in which features the model was permitted to see.</p>
+<p>After dropping gender and age (the protected attribute and its proxy), the gap closes to <strong>0.12 percentage points</strong> - a <strong>97.3% reduction</strong>. The gap wasn&#x27;t in the underlying merit of candidates - it was in which features the model was permitted to see.</p>
 <hr>
 <h3 id="detection-code">Detection Code</h3>
 <h4 id="measure-demographic-parity-gap">Measure demographic parity gap</h4>

--- a/explainers/demographic-parity.md
+++ b/explainers/demographic-parity.md
@@ -50,21 +50,15 @@ A model trained with gender and age as features assigned hire recommendations at
 
 | Group | Hire Rate |
 |---|---|
-| Male applicants | ~71% |
-| Female applicants | ~50% |
-| **Fairness Gap** | **~20.9 percentage points** |
+| Male applicants | 21.62% |
+| Female applicants | 17.10% |
+| **Fairness Gap** | **4.51 percentage points** |
+
+(The disparate-impact ratio here is 17.10 / 21.62 = 0.79, below the 0.80 four-fifths threshold.)
 
 The model was not told to discriminate. It learned to - by treating age as a proxy for gender, because women in the dataset more often had career gaps. Age was correlated with gender, so including it smuggled the gender signal back in even without an explicit gender rule.
 
-After dropping gender and age (the protected attribute and its proxy):
-
-| Group | Hire Rate |
-|---|---|
-| Male applicants | ~67% |
-| Female applicants | ~67% |
-| **New Fairness Gap** | **~0.12 percentage points** |
-
-**97.3% reduction.** The gap wasn't in the underlying merit of candidates - it was in which features the model was permitted to see.
+After dropping gender and age (the protected attribute and its proxy), the gap closes to **0.12 percentage points** - a **97.3% reduction**. The gap wasn't in the underlying merit of candidates - it was in which features the model was permitted to see.
 
 ---
 

--- a/explainers/disparate-treatment.html
+++ b/explainers/disparate-treatment.html
@@ -221,7 +221,7 @@ X = pd.get_dummies(df[[
 <pre><code class="language-python"># DISPARATE TREATMENT: Gender and Age are direct model features
 features = [&#x27;Gender&#x27;, &#x27;Age&#x27;, &#x27;Experience_Years&#x27;, &#x27;Technical_Test_Score&#x27;,
             &#x27;Education_Level&#x27;, &#x27;Previous_Companies&#x27;, &#x27;Distance_from_Company&#x27;]</code></pre>
-<p><code>Gender</code> is a direct input. <code>Age</code> is both an input and a proxy for gender (women in the dataset more often have career gaps, so age encodes gender signal twice over - once directly, once through correlation). The model was <em>designed</em> to see these attributes. The 20.9pp hire rate gap is the disparate impact.</p>
+<p><code>Gender</code> is a direct input. <code>Age</code> is both an input and a proxy for gender (women in the dataset more often have career gaps, so age encodes gender signal twice over - once directly, once through correlation). The model was <em>designed</em> to see these attributes. The 4.51pp hire rate gap (21.62% vs 17.10%) is the disparate impact.</p>
 <h4 id="the-fix-what-removing-disparate-treatment-looks-like">The Fix - What Removing Disparate Treatment Looks Like</h4>
 <pre><code class="language-python"># fair.py: protected attribute and its proxy removed
 features = [&#x27;Experience_Years&#x27;, &#x27;Technical_Test_Score&#x27;]

--- a/explainers/disparate-treatment.md
+++ b/explainers/disparate-treatment.md
@@ -69,7 +69,7 @@ features = ['Gender', 'Age', 'Experience_Years', 'Technical_Test_Score',
             'Education_Level', 'Previous_Companies', 'Distance_from_Company']
 ```
 
-`Gender` is a direct input. `Age` is both an input and a proxy for gender (women in the dataset more often have career gaps, so age encodes gender signal twice over - once directly, once through correlation). The model was *designed* to see these attributes. The 20.9pp hire rate gap is the disparate impact.
+`Gender` is a direct input. `Age` is both an input and a proxy for gender (women in the dataset more often have career gaps, so age encodes gender signal twice over - once directly, once through correlation). The model was *designed* to see these attributes. The 4.51pp hire rate gap (21.62% vs 17.10%) is the disparate impact.
 
 ### The Fix - What Removing Disparate Treatment Looks Like
 

--- a/explainers/neural-networks.html
+++ b/explainers/neural-networks.html
@@ -285,7 +285,7 @@ loss = binary_cross_entropy(y_true=0, y_pred=0.87)
     &#x27;communication_score&#x27;
 ]</code></pre>
 <p><strong>Results:</strong></p>
-<div class="explainer-table-wrap"><table class="explainer-table"><thead><tr><th>Group</th><th>Hire Rate</th></tr></thead><tbody><tr><td>Male candidates</td><td>61.2%</td></tr><tr><td>Female candidates</td><td>40.3%</td></tr><tr><td><strong>Fairness gap</strong></td><td><strong>20.9%</strong></td></tr></tbody></table></div>
+<div class="explainer-table-wrap"><table class="explainer-table"><thead><tr><th>Group</th><th>Hire Rate</th></tr></thead><tbody><tr><td>Male candidates</td><td>21.62%</td></tr><tr><td>Female candidates</td><td>17.10%</td></tr><tr><td><strong>Fairness gap</strong></td><td><strong>4.51 percentage points</strong></td></tr></tbody></table></div>
 <p>The network didn&#x27;t contain a rule that said &quot;prefer men.&quot; It learned from historical hiring data in which men were hired more. The weights encoded that pattern. The bias was invisible - buried in floating-point numbers across hidden layers.</p>
 <hr>
 <p><strong>Step 2 - Remove gender + proxy (our fix):</strong></p>
@@ -296,10 +296,9 @@ loss = binary_cross_entropy(y_true=0, y_pred=0.87)
     &#x27;technical_score&#x27;,
     &#x27;communication_score&#x27;
 ]</code></pre>
-<p><strong>Results:</strong></p>
-<div class="explainer-table-wrap"><table class="explainer-table"><thead><tr><th>Group</th><th>Hire Rate</th></tr></thead><tbody><tr><td>Male candidates</td><td>54.1%</td></tr><tr><td>Female candidates</td><td>54.0%</td></tr><tr><td><strong>Fairness gap</strong></td><td><strong>0.1%</strong></td></tr></tbody></table></div>
+<p><strong>Result:</strong> the fairness gap closes to <strong>0.12 percentage points</strong>.</p>
 <h4 id="summary">Summary</h4>
-<div class="explainer-table-wrap"><table class="explainer-table"><thead><tr><th>Approach</th><th>Fairness Gap</th><th>Reduction</th></tr></thead><tbody><tr><td>Biased model</td><td>20.9%</td><td>-</td></tr><tr><td>Remove gender only</td><td>~18%</td><td>Minimal</td></tr><tr><td>Remove gender + proxy</td><td>0.1%</td><td><strong>99.5%</strong></td></tr></tbody></table></div>
+<div class="explainer-table-wrap"><table class="explainer-table"><thead><tr><th>Approach</th><th>Fairness Gap</th><th>Reduction</th></tr></thead><tbody><tr><td>Biased model</td><td>4.51%</td><td>-</td></tr><tr><td>Remove gender only</td><td>barely moves (age still proxies it)</td><td>Minimal</td></tr><tr><td>Remove gender + proxy</td><td>0.12%</td><td><strong>97.3%</strong></td></tr></tbody></table></div>
 <p><strong>The network&#x27;s architecture didn&#x27;t change. The training procedure didn&#x27;t change. Only the inputs changed - and the bias disappeared.</strong></p>
 <hr>
 <h3 id="how-to-inspect-what-a-network-learned">How to Inspect What a Network Learned</h3>

--- a/explainers/neural-networks.md
+++ b/explainers/neural-networks.md
@@ -152,9 +152,9 @@ features = [
 
 | Group | Hire Rate |
 |---|---|
-| Male candidates | 61.2% |
-| Female candidates | 40.3% |
-| **Fairness gap** | **20.9%** |
+| Male candidates | 21.62% |
+| Female candidates | 17.10% |
+| **Fairness gap** | **4.51 percentage points** |
 
 The network didn't contain a rule that said "prefer men." It learned from historical hiring data in which men were hired more. The weights encoded that pattern. The bias was invisible - buried in floating-point numbers across hidden layers.
 
@@ -172,21 +172,15 @@ features = [
 ]
 ```
 
-**Results:**
-
-| Group | Hire Rate |
-|---|---|
-| Male candidates | 54.1% |
-| Female candidates | 54.0% |
-| **Fairness gap** | **0.1%** |
+**Result:** the fairness gap closes to **0.12 percentage points**.
 
 ### Summary
 
 | Approach | Fairness Gap | Reduction |
 |---|---|---|
-| Biased model | 20.9% | - |
-| Remove gender only | ~18% | Minimal |
-| Remove gender + proxy | 0.1% | **99.5%** |
+| Biased model | 4.51% | - |
+| Remove gender only | barely moves (age still proxies it) | Minimal |
+| Remove gender + proxy | 0.12% | **97.3%** |
 
 **The network's architecture didn't change. The training procedure didn't change. Only the inputs changed - and the bias disappeared.**
 

--- a/faircode/_explainers/demographic-parity.md
+++ b/faircode/_explainers/demographic-parity.md
@@ -50,21 +50,15 @@ A model trained with gender and age as features assigned hire recommendations at
 
 | Group | Hire Rate |
 |---|---|
-| Male applicants | ~71% |
-| Female applicants | ~50% |
-| **Fairness Gap** | **~20.9 percentage points** |
+| Male applicants | 21.62% |
+| Female applicants | 17.10% |
+| **Fairness Gap** | **4.51 percentage points** |
+
+(The disparate-impact ratio here is 17.10 / 21.62 = 0.79, below the 0.80 four-fifths threshold.)
 
 The model was not told to discriminate. It learned to - by treating age as a proxy for gender, because women in the dataset more often had career gaps. Age was correlated with gender, so including it smuggled the gender signal back in even without an explicit gender rule.
 
-After dropping gender and age (the protected attribute and its proxy):
-
-| Group | Hire Rate |
-|---|---|
-| Male applicants | ~67% |
-| Female applicants | ~67% |
-| **New Fairness Gap** | **~0.12 percentage points** |
-
-**97.3% reduction.** The gap wasn't in the underlying merit of candidates - it was in which features the model was permitted to see.
+After dropping gender and age (the protected attribute and its proxy), the gap closes to **0.12 percentage points** - a **97.3% reduction**. The gap wasn't in the underlying merit of candidates - it was in which features the model was permitted to see.
 
 ---
 

--- a/faircode/_explainers/disparate-treatment.md
+++ b/faircode/_explainers/disparate-treatment.md
@@ -69,7 +69,7 @@ features = ['Gender', 'Age', 'Experience_Years', 'Technical_Test_Score',
             'Education_Level', 'Previous_Companies', 'Distance_from_Company']
 ```
 
-`Gender` is a direct input. `Age` is both an input and a proxy for gender (women in the dataset more often have career gaps, so age encodes gender signal twice over - once directly, once through correlation). The model was *designed* to see these attributes. The 20.9pp hire rate gap is the disparate impact.
+`Gender` is a direct input. `Age` is both an input and a proxy for gender (women in the dataset more often have career gaps, so age encodes gender signal twice over - once directly, once through correlation). The model was *designed* to see these attributes. The 4.51pp hire rate gap (21.62% vs 17.10%) is the disparate impact.
 
 ### The Fix - What Removing Disparate Treatment Looks Like
 

--- a/faircode/_explainers/neural-networks.md
+++ b/faircode/_explainers/neural-networks.md
@@ -152,9 +152,9 @@ features = [
 
 | Group | Hire Rate |
 |---|---|
-| Male candidates | 61.2% |
-| Female candidates | 40.3% |
-| **Fairness gap** | **20.9%** |
+| Male candidates | 21.62% |
+| Female candidates | 17.10% |
+| **Fairness gap** | **4.51 percentage points** |
 
 The network didn't contain a rule that said "prefer men." It learned from historical hiring data in which men were hired more. The weights encoded that pattern. The bias was invisible - buried in floating-point numbers across hidden layers.
 
@@ -172,21 +172,15 @@ features = [
 ]
 ```
 
-**Results:**
-
-| Group | Hire Rate |
-|---|---|
-| Male candidates | 54.1% |
-| Female candidates | 54.0% |
-| **Fairness gap** | **0.1%** |
+**Result:** the fairness gap closes to **0.12 percentage points**.
 
 ### Summary
 
 | Approach | Fairness Gap | Reduction |
 |---|---|---|
-| Biased model | 20.9% | - |
-| Remove gender only | ~18% | Minimal |
-| Remove gender + proxy | 0.1% | **99.5%** |
+| Biased model | 4.51% | - |
+| Remove gender only | barely moves (age still proxies it) | Minimal |
+| Remove gender + proxy | 0.12% | **97.3%** |
 
 **The network's architecture didn't change. The training procedure didn't change. Only the inputs changed - and the bias disappeared.**
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1207,7 +1207,7 @@ features = ['Gender', 'Age', 'Experience_Years', 'Technical_Test_Score',
             'Education_Level', 'Previous_Companies', 'Distance_from_Company']
 ```
 
-`Gender` is a direct input. `Age` is both an input and a proxy for gender (women in the dataset more often have career gaps, so age encodes gender signal twice over - once directly, once through correlation). The model was *designed* to see these attributes. The 20.9pp hire rate gap is the disparate impact.
+`Gender` is a direct input. `Age` is both an input and a proxy for gender (women in the dataset more often have career gaps, so age encodes gender signal twice over - once directly, once through correlation). The model was *designed* to see these attributes. The 4.51pp hire rate gap (21.62% vs 17.10%) is the disparate impact.
 
 ### The Fix - What Removing Disparate Treatment Looks Like
 
@@ -1992,21 +1992,15 @@ A model trained with gender and age as features assigned hire recommendations at
 
 | Group | Hire Rate |
 |---|---|
-| Male applicants | ~71% |
-| Female applicants | ~50% |
-| **Fairness Gap** | **~20.9 percentage points** |
+| Male applicants | 21.62% |
+| Female applicants | 17.10% |
+| **Fairness Gap** | **4.51 percentage points** |
+
+(The disparate-impact ratio here is 17.10 / 21.62 = 0.79, below the 0.80 four-fifths threshold.)
 
 The model was not told to discriminate. It learned to - by treating age as a proxy for gender, because women in the dataset more often had career gaps. Age was correlated with gender, so including it smuggled the gender signal back in even without an explicit gender rule.
 
-After dropping gender and age (the protected attribute and its proxy):
-
-| Group | Hire Rate |
-|---|---|
-| Male applicants | ~67% |
-| Female applicants | ~67% |
-| **New Fairness Gap** | **~0.12 percentage points** |
-
-**97.3% reduction.** The gap wasn't in the underlying merit of candidates - it was in which features the model was permitted to see.
+After dropping gender and age (the protected attribute and its proxy), the gap closes to **0.12 percentage points** - a **97.3% reduction**. The gap wasn't in the underlying merit of candidates - it was in which features the model was permitted to see.
 
 ---
 
@@ -3728,9 +3722,9 @@ features = [
 
 | Group | Hire Rate |
 |---|---|
-| Male candidates | 61.2% |
-| Female candidates | 40.3% |
-| **Fairness gap** | **20.9%** |
+| Male candidates | 21.62% |
+| Female candidates | 17.10% |
+| **Fairness gap** | **4.51 percentage points** |
 
 The network didn't contain a rule that said "prefer men." It learned from historical hiring data in which men were hired more. The weights encoded that pattern. The bias was invisible - buried in floating-point numbers across hidden layers.
 
@@ -3748,21 +3742,15 @@ features = [
 ]
 ```
 
-**Results:**
-
-| Group | Hire Rate |
-|---|---|
-| Male candidates | 54.1% |
-| Female candidates | 54.0% |
-| **Fairness gap** | **0.1%** |
+**Result:** the fairness gap closes to **0.12 percentage points**.
 
 ### Summary
 
 | Approach | Fairness Gap | Reduction |
 |---|---|---|
-| Biased model | 20.9% | - |
-| Remove gender only | ~18% | Minimal |
-| Remove gender + proxy | 0.1% | **99.5%** |
+| Biased model | 4.51% | - |
+| Remove gender only | barely moves (age still proxies it) | Minimal |
+| Remove gender + proxy | 0.12% | **97.3%** |
 
 **The network's architecture didn't change. The training procedure didn't change. Only the inputs changed - and the bias disappeared.**
 


### PR DESCRIPTION
## Problem

`demographic-parity.md`, `disparate-treatment.md`, and `neural-networks.md` all present a **"~20.9 percentage point"** gender gap for the AI Fair Recruitment audit.

`20.9%` is `README.md`'s pull-quote for the **relative** reduction: `(21.62 - 17.10) / 21.62 = 20.9%`. It is not an absolute pp gap. The real absolute gap - per `README.md`'s canonical results table, and cited correctly by `disparate-impact.md` and `supervised-learning.md` - is **21.62% vs 17.10%, a 4.51pp gap**, closing to **0.12pp** (97.3% relative reduction) after dropping gender and age.

`demographic-parity.md` and `neural-networks.md` additionally invent their own per-group hire rates (`~71%`/`~50%`, `61.2%`/`40.3%`, `54.1%`/`54.0%`, `~67%`/`~67%`) that appear nowhere else in the repo, and `neural-networks.md`'s summary table has a fabricated `99.5%` reduction.

## Fix

Every AI Fair Recruitment number in the three files is now the canonical set (`21.62%` / `17.10%` / `4.51pp` -> `0.12pp` / `97.3%`). The fabricated post-fix per-group rates - which have **no canonical source** in the repo (the audits only produce the gap, not fixed per-group rates) - are dropped rather than replaced with new guesses. Pages, `faircode/_explainers/` mirror, and `llms-full.txt` regenerated.

`check_em_dash.py`, `check_broken_links.py`, `check_generated_files_current.py` pass.

Closes #550