### PR TITLE
fix: preserve reserved category names in the web profiler

### DIFF
--- a/assets/profiler-engine.js
+++ b/assets/profiler-engine.js
@@ -448,7 +448,7 @@
   }
 
   function nunique(rows, col) {
-    var seen = {};
+    var seen = Object.create(null);
     for (var i = 0; i < rows.length; i++) {
       var v = rows[i][col];
       if (v !== null) seen[v] = 1;
@@ -510,7 +510,7 @@
     return !/[+-]?\d+(?:\.\d+)?/.test(String(value));
   }
 
-  var AGE_BAND_LABELS = {};
+  var AGE_BAND_LABELS = Object.create(null);
   (function () {
     for (var i = 0; i < AGE_BANDS.length - 1; i++) {
       AGE_BAND_LABELS[AGE_BANDS[i] + '-' + AGE_BANDS[i + 1]] = true;
@@ -648,7 +648,7 @@
       }
       if (numericVals.length) {
         var skew = skewness(numericVals);
-        var counts = {}, nullCount = 0;
+        var counts = Object.create(null), nullCount = 0;
         for (i = 0; i < nums.length; i++) {
           var b = ageBand(nums[i]);
           if (b !== null) {
@@ -673,7 +673,9 @@
     }
 
     // Categorical path.
-    var c = {}, nulls = 0;
+    // Raw category labels may name Object.prototype properties. Keep them
+    // as literal keys, matching Python's value_counts().
+    var c = Object.create(null), nulls = 0;
     for (i = 0; i < nTotal; i++) {
       v = rows[i][name];
       if (v === null) nulls++;
@@ -728,7 +730,7 @@
     var la = labelize(table, a.name, a.kind);
     var lb = labelize(table, b.name, b.kind);
 
-    var ct = {}, aVals = {}, bVals = {}, i, key;
+    var ct = Object.create(null), aVals = Object.create(null), bVals = Object.create(null), i, key;
     for (i = 0; i < nTotal; i++) {
       if (la[i] === null || lb[i] === null) continue;
       aVals[la[i]] = 1; bVals[lb[i]] = 1;
@@ -766,14 +768,15 @@
     dimensions.forEach(function (d) {
       var ref = reference[d.name];
       if (!ref) return;
-      var actual = {};
+      var actual = Object.create(null);
       d.groups.forEach(function (g) { actual[g.label] = g.share; });
-      var labels = {};
+      var labels = Object.create(null);
       Object.keys(actual).forEach(function (l) { labels[l] = 1; });
       Object.keys(ref).forEach(function (l) { labels[l] = 1; });
       var groups = [], deviation = 0;
       Object.keys(labels).forEach(function (label) {
-        var exp = ref[label] || 0, act = actual[label] || 0, delta = act - exp;
+        var exp = Object.prototype.hasOwnProperty.call(ref, label) ? ref[label] : 0;
+        var act = actual[label] || 0, delta = act - exp;
         deviation += Math.abs(delta);
         groups.push({ label: String(label), expected: round(exp, 4),
                       actual: round(act, 4), delta: round(delta, 4) });
@@ -924,7 +927,7 @@
     Object.keys(byCol).forEach(function (col) {
       var pairs = byCol[col];
       var scale = pairs.some(function (p) { return p[1] > 1.5; }) ? 100 : 1;
-      reference[col] = {};
+      reference[col] = Object.create(null);
       pairs.forEach(function (p) { reference[col][p[0]] = p[1] / scale; });
     });
     return reference;
@@ -932,7 +935,7 @@
 
   // ── Dataset comparison / drift (SPEC section 8) ────────────────────────
   function shareMap(dim) {
-    var m = {};
+    var m = Object.create(null);
     dim.groups.forEach(function (g) { m[g.label] = g.share; });
     return m;
   }
@@ -982,7 +985,7 @@
       };
     }
     var sa = shareMap(dimA), sb = shareMap(dimB);
-    var labels = {};
+    var labels = Object.create(null);
     Object.keys(sa).forEach(function (l) { labels[l] = 1; });
     Object.keys(sb).forEach(function (l) { labels[l] = 1; });
 

--- a/faircode/SPEC.md
+++ b/faircode/SPEC.md
@@ -85,6 +85,10 @@ The band shares are then analyzed exactly like a categorical column.
 
 For a dimension with `k` groups and null-excluded normalized shares `p_1 … p_k` (each `p_i = count_i / N_nonnull`):
 
+Category labels are literal data, including names such as `__proto__`, `constructor`,
+and `toString`. They must be retained in distinct counts, groups, intersections,
+reference baselines, and drift comparisons, with no inherited-property lookups.
+
 - **shares** - the `p_i`, descending, with raw counts.
 - **ci_low / ci_high** - a 95% **Wilson score interval** on each group's share, so a share read off a small sample carries its sampling uncertainty. For a group with count `c` out of `N_nonnull = n`, `p = c/n`, `z = 1.959963984540054`:
   - `center = (p + z²/2n) / (1 + z²/n)`, `margin = (z / (1 + z²/n)) · √( p(1−p)/n + z²/4n² )`

--- a/tests/test_js_category_keys.py
+++ b/tests/test_js_category_keys.py
@@ -1,0 +1,110 @@
+"""Category labels must be data, even when they name JavaScript properties."""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from faircode import compare, profile
+from faircode.profiler import parse_reference
+
+ROOT = Path(__file__).resolve().parent.parent
+PROPERTY_NAMES = ["__proto__", "constructor", "toString", "hasOwnProperty"]
+
+
+def js_result(script, data):
+    completed = subprocess.run(
+        ["node", "-e", "const fs=require('fs');require('./assets/profiler-engine.js');"
+         "const E=globalThis.FairCodeProfiler;"
+         "const data=JSON.parse(fs.readFileSync(0,'utf8'));" + script],
+        input=json.dumps(data), cwd=ROOT, text=True, encoding="utf-8",
+        capture_output=True, check=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def structured(result):
+    return {key: value for key, value in result.items() if key != "flags"}
+
+
+@pytest.mark.parametrize("label", PROPERTY_NAMES)
+@pytest.mark.parametrize("column", ["sex", "segment", "age"])
+def test_property_named_categories_match_python(label, column):
+    # segment exercises automatic categorical detection; age exercises the
+    # numeric-band plus free-text-sentinel path. Both intersection axes use
+    # the property-named label and include absent cross-product cells.
+    ordinary = "25" if column == "age" else "Male"
+    df = pd.DataFrame({
+        column: [ordinary] * 3 + [label] * 3 + ["Female"] * 2,
+        "race": ["White"] * 3 + [label] * 3 + ["Black"] * 2,
+    })
+    actual = js_result(
+        "process.stdout.write(JSON.stringify(E.profile(E.parseCSV(data))));",
+        df.to_csv(index=False),
+    )
+    expected = profile(df)
+    assert structured(actual) == structured(expected)
+    assert actual["dimensions"][0]["n_groups"] == 3
+    special = next(g for g in actual["dimensions"][0]["groups"] if g["label"] == label)
+    assert special["count"] == 3
+    assert special["share"] == 3 / 8
+
+
+@pytest.mark.parametrize("label", PROPERTY_NAMES)
+def test_property_named_categories_preserve_reference_and_drift(label):
+    a = pd.DataFrame({"sex": [label] * 3 + ["Female"] * 5})
+    b = pd.DataFrame({"sex": [label] * 5 + ["Male"] * 3})
+    ref = pd.DataFrame({"column": ["sex", "sex"],
+                        "group": [label, "Female"], "share": [0.5, 0.5]})
+    expected_reference = parse_reference(ref)
+    result = js_result(
+        "const ref=E.parseReference(E.parseCSV(data.reference));"
+        "const a=E.profile(E.parseCSV(data.a),null,{reference:ref});"
+        "const b=E.profile(E.parseCSV(data.b));"
+        "process.stdout.write(JSON.stringify({reference:ref,profile:a,"
+        "comparison:E.compare(a,b,'A','B')}));",
+        {"a": a.to_csv(index=False), "b": b.to_csv(index=False),
+         "reference": ref.to_csv(index=False)},
+    )
+    expected_a = profile(a, opts={"reference": expected_reference})
+    assert result["reference"] == expected_reference
+    assert structured(result["profile"]) == structured(expected_a)
+    assert structured(result["comparison"]) == structured(compare(expected_a, profile(b), "A", "B"))
+
+
+def test_property_named_category_counts_toward_detection_threshold():
+    df = pd.DataFrame({"segment": ["normal", "__proto__"]})
+    actual = js_result(
+        "process.stdout.write(JSON.stringify(E.profile(E.parseCSV(data))));",
+        df.to_csv(index=False),
+    )
+    assert structured(actual) == structured(profile(df))
+    assert len(actual["dimensions"]) == 1
+
+
+@pytest.mark.parametrize("label", PROPERTY_NAMES)
+def test_property_named_category_absent_from_reference_is_zero(label):
+    df = pd.DataFrame({"sex": [label, "Female"]})
+    reference = {"sex": {"Female": 1}}
+    actual = js_result(
+        "process.stdout.write(JSON.stringify(E.profile(E.parseCSV(data.csv),"
+        "null,{reference:data.reference})));",
+        {"csv": df.to_csv(index=False), "reference": reference},
+    )
+    assert structured(actual) == structured(profile(df, opts={"reference": reference}))
+
+
+@pytest.mark.parametrize("label", PROPERTY_NAMES)
+def test_property_named_age_category_is_not_a_numeric_age_band(label):
+    a = pd.DataFrame({"age": [label, label]})
+    b = pd.DataFrame({"age": ["25", "35"]})
+    actual = js_result(
+        "process.stdout.write(JSON.stringify(E.compare("
+        "E.profile(E.parseCSV(data.a)),E.profile(E.parseCSV(data.b)),'A','B')));",
+        {"a": a.to_csv(index=False), "b": b.to_csv(index=False)},
+    )
+    expected = compare(profile(a), profile(b), "A", "B")
+    assert expected["dimensions"][0]["kind_mismatch"] is True
+    assert structured(actual) == structured(expected)


### PR DESCRIPTION
## Summary

Preserve literal category labels such as `__proto__`, `constructor`, `toString`, and `hasOwnProperty` throughout the JavaScript profiler. Plain-object dictionaries previously dropped or corrupted these labels; the eight-row example in #574 showed 60% / 40% instead of 37.5% / 37.5% / 25%.

Use prototype-free dictionaries for category counts, distinct values, intersections, references, and drift shares, plus own-property reference lookup. Also prevent reserved property names from being mistaken for numeric age bands. Clarify the literal-label contract in SPEC.md. Python already follows that contract; its metrics and algorithms are unchanged.

## Type

- [ ] Audit
- [ ] Explainer
- [x] Bug fix
- [ ] Other

## Validation

- 25 new Python/JavaScript regressions: failed before the corresponding fixes, pass afterward.
- Combined new and existing JS parity tests: 52 passed, 1 pre-existing failure.
- Full available suite on Windows: 299 passed, 14 skipped, 4 failures. All four failures also reproduce from an untouched upstream checkout at `436b87a`:
  - `test_main_catches_an_uncommitted_edit_never_rebuilt`
  - `test_main_flags_a_missing_og_image`
  - `test_python_js_profiler_parity_sniffs_quoted_newlines`
  - `test_main_directory_as_input_fails_cleanly`
- Optional benchmark/model/manifest/MCP/Parquet dependencies account for the skipped tests.
- Ruff, em-dash lint, internal-link check, and `git diff --check` pass.
- Actual Chrome upload of the eight-row CSV reproduces the original dropped group and verifies the fixed 37.5% / 37.5% / 25% display and restored intersections.

Commands: `python -m pytest tests/test_js_category_keys.py tests/test_js_parity.py -q`, `python -m pytest tests/ -q -ra`, `ruff check faircode scripts tests`, `python scripts/check_em_dash.py`, `python scripts/check_broken_links.py`.

The synthetic CSV is regression input, not a new fairness audit. No audit datasets, published benchmark results, or model behavior change. Full audit/model benchmark jobs were not run locally.

## Linked issue

Closes #574.
