### PR TITLE
fix(profiler): recover the results panel when a threshold input is rejected

### DIFF
--- a/assets/profiler-ui.js
+++ b/assets/profiler-ui.js
@@ -484,6 +484,8 @@
     input.addEventListener('input', function () {
       var opt = input.dataset.opt;
       var raw = input.value.trim();
+      var hadPrevious = Object.prototype.hasOwnProperty.call(currentOpts, opt);
+      var previous = currentOpts[opt];
       if (raw === '') {
         delete currentOpts[opt];
         input.classList.remove('overridden');
@@ -493,7 +495,22 @@
         currentOpts[opt] = num;
         input.classList.add('overridden');
       }
-      reprofile(false);
+      if (!reprofile(false)) {
+        // The value just typed is outside the range validateOpts() accepts
+        // (e.g. min_share 1.5, see #511), so reprofile() failed and
+        // showError() hid the whole #results panel, including this very
+        // input, leaving no way to correct the number. Revert this opt to
+        // its last-known-good value (or back to the engine default when it
+        // was never set) and retry once, mirroring the #466 recovery the
+        // mapping-select handler already uses.
+        if (hadPrevious) {
+          currentOpts[opt] = previous;
+        } else {
+          delete currentOpts[opt];
+        }
+        input.classList.toggle('overridden', hadPrevious);
+        reprofile(false);
+      }
     });
   });
 

--- a/tests/test_js_parity.py
+++ b/tests/test_js_parity.py
@@ -607,3 +607,26 @@ def test_python_js_compare_parity(csv_name):
             result[side].pop("name", None)
 
     assert javascript_result == python_result
+
+
+def test_threshold_input_recovers_panel_after_invalid_value():
+    """profiler-ui.js's threshold-input handler must recover when the engine
+    rejects the typed value (e.g. min_share 1.5, see #602): reprofile() fails
+    and showError() hides the whole #results panel, including the very input
+    the user needs to correct. The handler must revert that opt to its
+    last-known-good value and retry once, the same recovery the mapping-select
+    handler got in #466. Source-level check (mirrors
+    test_compare_card_renderers_special_case_kind_mismatch) - this handler is
+    DOM-coupled and has no unit harness."""
+    src = (REPO_ROOT / "assets" / "profiler-ui.js").read_text(encoding="utf-8")
+
+    marker = "thresholdInputs.forEach(function (input) {\n    input.addEventListener('input'"
+    handler = src[src.index(marker):]
+    handler = handler[: handler.index("\n  });\n")]
+
+    # it must notice that the re-profile failed ...
+    assert "if (!reprofile(false))" in handler
+    # ... revert the offending opt to the value it held before ...
+    assert "currentOpts[opt] = previous;" in handler
+    # ... and retry once so the #results panel (and this input) come back
+    assert handler.count("reprofile(false)") >= 2


### PR DESCRIPTION
**What**: The web profiler's advanced threshold inputs (`min_share`, `intersection_floor`, `imbalance_flag`, `missing_flag`, `min_group_size`) can no longer strand the user behind a hidden results panel when an out-of-range value is typed.

**Why**: The threshold controls are nested inside `<section id="results">`. Typing an out-of-range value (for example `1.5` into "Min share") makes the engine's `validateOpts()` throw inside `reprofile()`, which calls `showError()` and sets `results.hidden = true`, hiding the very input the user needs to correct. The only way out was to re-select the file from scratch. Reported in #602.

**How**: In `assets/profiler-ui.js`, the threshold-input `input` handler now remembers that opt's last-known-good value before applying the typed one. If `reprofile()` fails, it reverts that single opt (or deletes it when it was never set, so the engine default applies), restores the input's `overridden` state, and retries once. This mirrors the recovery the mapping-select handler already uses for #466, and leaves the panel visible so the number can be fixed.

**Tests**:
- New `tests/test_js_parity.py::test_threshold_input_recovers_panel_after_invalid_value`, a source-level regression test following this repo's existing convention for DOM-coupled handlers (`test_compare_card_renderers_special_case_kind_mismatch`).
- Full suite: `pytest tests/ -q` -> 256 passed, 34 skipped.
- `python3 scripts/check_em_dash.py` -> OK.

**Mutation check**: reverting the handler to the pre-fix single `reprofile(false);` call makes the new test fail on `assert 'if (!reprofile(false))' in handler`; restoring the fix makes it pass again.

Note: implemented with AI assistance (OpenCode plus muse-spark), reviewed and verified locally against the full test suite.

Fixes #602
